### PR TITLE
TC-137 Update platform SDK scenario wording 

### DIFF
--- a/examples/BYOAuthFlow/Program.cs
+++ b/examples/BYOAuthFlow/Program.cs
@@ -27,7 +27,7 @@ namespace BYOAuthFlow
         /// <summary>
         ///     PLEASE REPLACE.
         ///     Your SpatialOS project name.
-        ///     It should be the same as the name specified in the local spatialos.json file used to start the local API services.
+        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service ("spatiald").
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 

--- a/examples/BYOAuthFlow/Program.cs
+++ b/examples/BYOAuthFlow/Program.cs
@@ -27,7 +27,7 @@ namespace BYOAuthFlow
         /// <summary>
         ///     PLEASE REPLACE.
         ///     Your SpatialOS project name.
-        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service ("spatiald").
+        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service.
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 

--- a/examples/BYOAuthFlow/Program.cs
+++ b/examples/BYOAuthFlow/Program.cs
@@ -15,7 +15,7 @@ using LocatorParameters = Improbable.Worker.Alpha.LocatorParameters;
 namespace BYOAuthFlow
 {
     /// <summary>
-    ///     This contains the implementation of the "integrate your own authentication provider" scenario.
+    ///     This contains the implementation of the "Player authentication" scenario.
     ///     1. Start a cloud deployment.
     ///     2. Create a PlayerIdentityToken.
     ///     3. Choose a deployment that is ready for login.
@@ -25,20 +25,20 @@ namespace BYOAuthFlow
     internal class BYOAuthScenario : ScenarioBase
     {
         /// <summary>
-        ///     PLEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     Your SpatialOS project name.
         ///     It should be the same as the name specified in the local spatialos.json file used to start the local API services.
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 
         /// <summary>
-        ///     PLEASE REPLACE ME.
-        ///     The path to a valid launch configuration json file.
+        ///     PLEASE REPLACE.
+        ///     The path to a valid launch configuration JSON file.
         /// </summary>
         private const string LaunchConfigFilePath = "../blank_project/default_launch.json";
 
         /// <summary>
-        ///     PLEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The assembly you want the cloud deployment to use.
         /// </summary>
         private const string AssemblyId = "blank_project";
@@ -49,7 +49,7 @@ namespace BYOAuthFlow
         private const string ScenarioWorkerType = "UnityClient";
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The name of the deployment.
         /// </summary>
         private static readonly string DeploymentName = $"byoauth_{StringUtils.Random(6)}";
@@ -66,7 +66,7 @@ namespace BYOAuthFlow
         private Deployment _deployment;
 
         /// <summary>
-        ///     PLEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The SpatialOS refresh token of a service account or a user account.
         /// </summary>
         private static string RefreshToken =>

--- a/examples/CapacityLimit/Program.cs
+++ b/examples/CapacityLimit/Program.cs
@@ -20,7 +20,7 @@ namespace CapacityLimit
         /// <summary>
         ///     PLEASE REPLACE.
         ///     Your SpatialOS project name.
-        ///     It should be the same as the name specified in the local `spatialos.json` file used to start the local API service ("spatiald").
+        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service ("spatiald").
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 
@@ -59,7 +59,7 @@ namespace CapacityLimit
 
         /// <summary>
         ///     PLEASE REPLACE.
-        ///     The SpatialOS Platform refresh token for a service account or a user account.
+        ///     The SpatialOS refresh token for a service account or a user account.
         /// </summary>
         private static string RefreshToken =>
             Environment.GetEnvironmentVariable("IMPROBABLE_REFRESH_TOKEN") ?? "PLEASE_REPLACE_ME";

--- a/examples/CapacityLimit/Program.cs
+++ b/examples/CapacityLimit/Program.cs
@@ -20,7 +20,7 @@ namespace CapacityLimit
         /// <summary>
         ///     PLEASE REPLACE.
         ///     Your SpatialOS project name.
-        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service ("spatiald").
+        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service.
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 

--- a/examples/CapacityLimit/Program.cs
+++ b/examples/CapacityLimit/Program.cs
@@ -18,20 +18,20 @@ namespace CapacityLimit
     internal class CapacityLimitScenario : ScenarioBase
     {
         /// <summary>
-        ///     PLEASE REPLACE ME.
-        ///     You SpatialOS project name.
-        ///     It should be the same as the name specified in the local `spatialos.json` file used to start the local API service.
+        ///     PLEASE REPLACE.
+        ///     Your SpatialOS project name.
+        ///     It should be the same as the name specified in the local `spatialos.json` file used to start the local API service ("spatiald").
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 
         /// <summary>
-        ///     PLEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The assembly you want the cloud deployment to use.
         /// </summary>
         private const string AssemblyId = "blank_project";
 
         /// <summary>
-        ///     PLEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The path to a valid launch configuration JSON file.
         /// </summary>
         private const string LaunchConfigFilePath = "../blank_project/capacity_launch.json";
@@ -41,7 +41,7 @@ namespace CapacityLimit
         private const int LocatorServerPort = 443;
 
         /// <summary>
-        ///     PLEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The name of the deployment.
         /// </summary>
         private static readonly string DeploymentName = $"capacity_limited_{StringUtils.Random(6)}";
@@ -58,7 +58,7 @@ namespace CapacityLimit
         private Deployment _deployment;
 
         /// <summary>
-        ///     PLEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The SpatialOS Platform refresh token for a service account or a user account.
         /// </summary>
         private static string RefreshToken =>
@@ -88,7 +88,7 @@ namespace CapacityLimit
         }
 
         /// <summary>
-        ///     This contains the implementation of the capacity limit scenario.
+        ///     This contains the implementation of the "Capacity limiting" scenario.
         ///     1. Gets the currently running cloud deployment that has a capacity limit.
         ///     2. Tests that connecting more clients than the capacity limit fails.
         ///     3. Updates the deployment to increase the capacity limit.

--- a/examples/GameMaintenance/Program.cs
+++ b/examples/GameMaintenance/Program.cs
@@ -15,7 +15,7 @@ namespace GameMaintenance
         /// <summary>
         ///     PLEASE REPLACE.
         ///     Your SpatialOS project name.
-        ///     It should be the same as the name specified in the local `spatialos.json` file used to start the local API service ("spatiald").
+        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service ("spatiald").
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 

--- a/examples/GameMaintenance/Program.cs
+++ b/examples/GameMaintenance/Program.cs
@@ -15,7 +15,7 @@ namespace GameMaintenance
         /// <summary>
         ///     PLEASE REPLACE.
         ///     Your SpatialOS project name.
-        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service ("spatiald").
+        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service.
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 

--- a/examples/GameMaintenance/Program.cs
+++ b/examples/GameMaintenance/Program.cs
@@ -13,33 +13,33 @@ namespace GameMaintenance
     internal class Program
     {
         /// <summary>
-        ///     PlEASE REPLACE ME.
-        ///     You SpatialOS project name.
-        ///     It should be the same as the name specified in the local spatialos.json file used to start spatiald.
+        ///     PLEASE REPLACE.
+        ///     Your SpatialOS project name.
+        ///     It should be the same as the name specified in the local `spatialos.json` file used to start the local API service ("spatiald").
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The name of the deployment.
         /// </summary>
         private static readonly string DeploymentName = $"game_maintenance_{StringUtils.Random(6)}";
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
-        ///     The assembly you would want the cloud deployment to use.
+        ///     PLEASE REPLACE.
+        ///     The assembly you want the cloud deployment to use.
         /// </summary>
         private const string AssemblyId = "blank_project";
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The path to a valid snapshot for the target assembly.
         /// </summary>
         private const string SnapshotFilePath =  "../blank_project/snapshots/default.snapshot" ;
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
-        ///     The path to a valid launch configuration json file.
+        ///     PLEASE REPLACE.
+        ///     The path to a valid launch configuration JSON file.
         /// </summary>
         private const string LaunchConfigFilePath = "../blank_project/default_launch.json";
 
@@ -53,14 +53,14 @@ namespace GameMaintenance
             SnapshotServiceClient.Create(credentials: CredentialWithProvidedToken);
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The SpatialOS Platform refresh token of a service account or a user account.
         /// </summary>
         private static string RefreshToken =>
             Environment.GetEnvironmentVariable("IMPROBABLE_REFRESH_TOKEN") ?? "PLEASE_REPLACE_ME";
 
         /// <summary>
-        ///     This contains the implementation of the game maintenance scenario.
+        ///     This contains the implementation of the "Game maintenance" scenario.
         ///     1. Get the currently running cloud deployment that needs taking down for maintenance.
         ///     2. Lock down the deployment by removing the `live` tag and setting the worker flag.
         ///     3. Take a snapshot of the deployment.

--- a/examples/ReplicateState/Program.cs
+++ b/examples/ReplicateState/Program.cs
@@ -11,33 +11,33 @@ namespace ReplicateState
     internal class Program
     {
         /// <summary>
-        ///     PlEASE REPLACE ME.
-        ///     You SpatialOS project name.
-        ///     It should be the same as the name specified in the local spaitalos.json file used to start spatiald.
+        ///     PLEASE REPLACE.
+        ///     Your SpatialOS project name.
+        ///     It should be the same as the name specified in the local spatialos.json file used to start the local API service ("spatiald").
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The name of the deployment.
         /// </summary>
         private static readonly string DeploymentName = $"snapshot_upload_{StringUtils.Random(6)}";
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
-        ///     The path to a valid launch configuration json file.
+        ///     PLEASE REPLACE.
+        ///     The path to a valid launch configuration JSON file.
         /// </summary>
         private const string LaunchConfigFilePath = "../blank_project/default_launch.json";
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
-        ///     The assembly you would want the cloud deployment to use.
+        ///     PLEASE REPLACE.
+        ///     The assembly you want the cloud deployment to use.
         /// </summary>
         private const string AssemblyId = "blank_project";
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
-        ///     The port spatiald is running on.
+        ///     PLEASE REPLACE.
+        ///     The port that the local API service is running on.
         /// </summary>
         private const int SpatialDPort = 9876;
 
@@ -67,14 +67,14 @@ namespace ReplicateState
             DeploymentServiceClient.Create(SpatialdEndpoint);
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The SpatialOS Platform refresh token of a service account or a user account.
         /// </summary>
         private static string RefreshToken =>
             Environment.GetEnvironmentVariable("IMPROBABLE_REFRESH_TOKEN") ?? "PLEASE_REPLACE_ME";
 
         /// <summary>
-        ///     This contains the implementation of the "replicate local state to cloud" scenario.
+        ///     This contains the implementation of the "Replicate local state to cloud" scenario.
         ///     1. Take a snapshot of a local deployment.
         ///     2. Download the local snapshot to a temporary address.
         ///     3. Upload the local snapshot to the cloud through in three steps:
@@ -159,15 +159,15 @@ namespace ReplicateState
         }
 
         /// <summary>
-        ///     This assumes you already have a running spatiald process at the specified port.
-        ///     For more information about how to start a spatiald process, please visit the accompanying documentation on
+        ///     This assumes you already have the local API service ("spatiald") running at the specified port.
+        ///     For more information about how to start the local API service, visit the accompanying documentation on
         ///     https://docs.improbable.io/reference/latest//platform-sdk/local-api.
         ///     This starts a local deployment using the blank SpatialOS project included in this repository.
         /// </summary>
         private static void Setup()
         {
             Console.WriteLine("Setting up for the scenario");
-            Console.WriteLine($"Assuming spatiald is running at localhost:{SpatialDPort}");
+            Console.WriteLine($"Assuming the local API service is running at localhost:{SpatialDPort}");
             Console.WriteLine("Starting a local deployment");
             var launchConfig = File.ReadAllText(LaunchConfigFilePath);
             _localDeployment = LocalDeploymentServiceClient.CreateDeployment(new CreateDeploymentRequest

--- a/examples/ReplicateState/Program.cs
+++ b/examples/ReplicateState/Program.cs
@@ -13,7 +13,7 @@ namespace ReplicateState
         /// <summary>
         ///     PLEASE REPLACE.
         ///     Your SpatialOS project name.
-        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service ("spatiald").
+        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service.
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 

--- a/examples/ReplicateState/Program.cs
+++ b/examples/ReplicateState/Program.cs
@@ -13,7 +13,7 @@ namespace ReplicateState
         /// <summary>
         ///     PLEASE REPLACE.
         ///     Your SpatialOS project name.
-        ///     It should be the same as the name specified in the local spatialos.json file used to start the local API service ("spatiald").
+        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service ("spatiald").
         /// </summary>
         private const string ProjectName = "platform_sdk_examples";
 
@@ -68,7 +68,7 @@ namespace ReplicateState
 
         /// <summary>
         ///     PLEASE REPLACE.
-        ///     The SpatialOS Platform refresh token of a service account or a user account.
+        ///     The SpatialOS refresh token of a service account or a user account.
         /// </summary>
         private static string RefreshToken =>
             Environment.GetEnvironmentVariable("IMPROBABLE_REFRESH_TOKEN") ?? "PLEASE_REPLACE_ME";

--- a/examples/ServiceAccountMaintenance/Program.cs
+++ b/examples/ServiceAccountMaintenance/Program.cs
@@ -11,7 +11,7 @@ namespace ServiceAccountMaintenance
     internal class Program
     {
         /// <summary>
-        ///     PLEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     Your SpatialOS project name.
         ///     This scenario will create a new service account with read and write access to this project.
         /// </summary>
@@ -33,7 +33,7 @@ namespace ServiceAccountMaintenance
         private const int NumberOfServiceAccountsToCreate = 10;
 
         /// <summary>
-        ///     PLEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The name given to service accounts created during setup.
         /// </summary>
         private const string ServiceAccountName = "sa_maintenance_scenario";
@@ -47,7 +47,7 @@ namespace ServiceAccountMaintenance
         private static List<long> ServiceAccountIds;
 
         /// <summary>
-        ///     PlEASE REPLACE ME.
+        ///     PLEASE REPLACE.
         ///     The SpatialOS Platform refresh token of a service account or a user account.
         /// </summary>
         private static string RefreshToken =>
@@ -55,7 +55,7 @@ namespace ServiceAccountMaintenance
 
 
         /// <summary>
-        ///     This contains the implementation of the "service account maintenance" scenario.
+        ///     This contains the implementation of the "Service account maintenance" scenario.
         ///     1. Iterate over the service accounts in your project.
         ///     2. If a service account has expired, or is close to expiry, prolong the expiry time to some point in the
         ///     future.


### PR DESCRIPTION
Couple of questions/suggestions:

- Is there any reason why sometimes the summary list is at the top, and sometimes it's lower down, below all the "PLEASE REPLACE"s? Being at the top makes sense to me, but I wanted to check.

- What do you think about potentially changing the wording in the GitHub steps so that it matches the wording in the docs? In some cases, the GitHub steps and the docs steps don't actually match each other, whereas in other cases they match up but use inconsistent wording.
E.g. at the moment the "Player authentication" scenario is like this in the docs:

1. Instantiate clients
2. Create a player identity token (PIT) for a project
3. Choose a deployment that the player is allowed to join
4. Create a login token (LT) to grant access to a player to a given SpatialOS deployment
5. Connect to the deployment using both PIT and LT

but like this in the code:

1. Start a cloud deployment.
2. Create a PlayerIdentityToken.
3. Choose a deployment that is ready for login.
4. Create a LoginToken for a selected deployment.
5. Connect to the deployment using the PlayerIdentityToken and the LoginToken.

