### PR TITLE
Merge SDK dependencies into one assembly

### DIFF
--- a/apis/apis.csproj
+++ b/apis/apis.csproj
@@ -15,6 +15,40 @@
 
     <ItemGroup>
       <PackageReference Include="Google.LongRunning" Version="1.0.0" />
+      <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
     </ItemGroup>
+
+    <Target Name="ILRepack" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release' ">
+        <PropertyGroup>
+            <WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\net451</WorkingDirectory>
+        </PropertyGroup>
+
+        <ItemGroup>
+            <InputAssemblies Include="Google.Protobuf.dll" />
+            <InputAssemblies Include="System.Interactive.Async.dll" />
+            <InputAssemblies Include="Newtonsoft.Json.dll" />
+            <InputAssemblies Include="Grpc.Core.dll" />
+            <InputAssemblies Include="Grpc.Auth.dll" />
+            <InputAssemblies Include="Google.Protobuf.dll" />
+            <InputAssemblies Include="Google.LongRunning.dll" />
+            <InputAssemblies Include="Google.Apis.PlatformServices.dll" />
+            <InputAssemblies Include="Google.Apis.dll" />
+            <InputAssemblies Include="Google.Apis.Core.dll" />
+            <InputAssemblies Include="Google.Apis.Auth.PlatformServices.dll" />
+            <InputAssemblies Include="Google.Apis.Auth.dll" />
+            <InputAssemblies Include="Google.Api.Gax.Grpc.dll" />
+            <InputAssemblies Include="Google.Api.Gax.dll" />
+            <InputAssemblies Include="Google.Api.CommonProtos.dll" />
+        </ItemGroup>
+        
+        <ILRepack Parallel="true" OutputType="$(OutputType)" MainAssembly="$(AssemblyName).dll" OutputAssembly="$(AssemblyName).dll" InputAssemblies="@(InputAssemblies)" Internalize="false" WorkingDirectory="$(WorkingDirectory)" />
+
+        <ItemGroup>
+            <AssembliesToDelete Include="$(WorkingDirectory)/%(InputAssemblies.Identity)" />
+        </ItemGroup>
+
+        <Delete Files="@(AssembliesToDelete)" />
+        
+    </Target>
 
 </Project>

--- a/apis/apis.csproj
+++ b/apis/apis.csproj
@@ -40,8 +40,16 @@
             <InputAssemblies Include="Google.Api.Gax.dll" />
             <InputAssemblies Include="Google.Api.CommonProtos.dll" />
         </ItemGroup>
+
+        <!-- These DLLs are not internalised because they contains types that are user-facing. Internalising would mess up the namespace. -->
+        <ItemGroup>
+            <InternalizeExcludeAssemblies Include="^Google.Api.Gax" />
+            <InternalizeExcludeAssemblies Include="^Google.Protobuf.WellKnownTypes" />
+            <InternalizeExcludeAssemblies Include="^Grpc.Core" />
+            <InternalizeExcludeAssemblies Include="^Google.LongRunning" />
+        </ItemGroup>
         
-        <ILRepack Parallel="true" OutputType="$(OutputType)" MainAssembly="$(AssemblyName).dll" OutputAssembly="$(AssemblyName).dll" InputAssemblies="@(InputAssemblies)" Internalize="false" WorkingDirectory="$(WorkingDirectory)" />
+        <ILRepack Parallel="true" OutputType="$(OutputType)" MainAssembly="$(AssemblyName).dll" OutputAssembly="$(AssemblyName).dll" InputAssemblies="@(InputAssemblies)"  InternalizeExcludeAssemblies="@(InternalizeExcludeAssemblies)" Internalize="true" WorkingDirectory="$(WorkingDirectory)" />
 
         <ItemGroup>
             <AssembliesToDelete Include="$(WorkingDirectory)/%(InputAssemblies.Identity)" />

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,7 +24,7 @@ rm -rf "${ARTEFACT_DIR}"
 mkdir -p "${ARTEFACT_DIR}"
 
 echo "--- Preparing artefacts for release"
-msbuild $REPO_ROOT/apis/apis.csproj /t:Restore
+msbuild "${REPO_ROOT}/apis/apis.csproj" /t:Restore
 msbuild "${REPO_ROOT}/apis/apis.csproj" \
   /p:Configuration=Release \
   /p:Version="${SDK_VERSION}" \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,6 +24,7 @@ rm -rf "${ARTEFACT_DIR}"
 mkdir -p "${ARTEFACT_DIR}"
 
 echo "--- Preparing artefacts for release"
+msbuild $REPO_ROOT/apis/apis.csproj /t:Restore
 msbuild "${REPO_ROOT}/apis/apis.csproj" \
   /p:Configuration=Release \
   /p:Version="${SDK_VERSION}" \


### PR DESCRIPTION
As titled: 
This combines all required DLLs into one to avoid conflicting popular DLLs like Newtonsoft JSON.