### PR TITLE
[COMP-673] Add description and runtime version

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -14,7 +14,7 @@ common: &common
     # TODO(EV): Make docs better. (https://github.com/improbable/platform/blob/master/docs/product-groups/dev-workflow/buildkite/how-to-deploy-change-to-agents.md)
     - "capable_of_building=platform"
     - "environment=production"
-    - "queue=v-ccadbedf01b84f29-------1540485662"
+    - "queue=v2-1545678177-378924f50bfed5a0-------z"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:
     automatic:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,8 +61,8 @@ git_repository(
 git_repository(
     name = "improbable_platform",
     remote = "git@github.com:improbable/platform.git",
-    commit = "246c6a1db4e352b51f4d2197cdf600077ab41bce",
-    shallow_since = "2018-12-01",
+    commit = "777672f36dbc103621ee04dec1786da2cdd48599",
+    shallow_since = "2019-02-01",
 )
 
 new_git_repository(

--- a/apis/deployment_v1alpha1/Deployment.cs
+++ b/apis/deployment_v1alpha1/Deployment.cs
@@ -28,7 +28,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
             "b25zLnByb3RvGiBnb29nbGUvcHJvdG9idWYvZmllbGRfbWFzay5wcm90bxof",
             "Z29vZ2xlL3Byb3RvYnVmL3RpbWVzdGFtcC5wcm90bxoeZ29vZ2xlL3Byb3Rv",
             "YnVmL2R1cmF0aW9uLnByb3RvGjZnaXRodWIuY29tL213aXRrb3cvZ28tcHJv",
-            "dG8tdmFsaWRhdG9ycy92YWxpZGF0b3IucHJvdG8ijQcKCkRlcGxveW1lbnQS",
+            "dG8tdmFsaWRhdG9ycy92YWxpZGF0b3IucHJvdG8iuwcKCkRlcGxveW1lbnQS",
             "CgoCaWQYASABKAkSLQoMcHJvamVjdF9uYW1lGAIgASgJQhfi3x8TChFeW2Et",
             "ejAtOV9dezMsMzJ9JBIlCgRuYW1lGAMgASgJQhfi3x8TChFeW2EtejAtOV9d",
             "ezMsMzJ9JBITCgtyZWdpb25fY29kZRgEIAEoCRIUCgxjbHVzdGVyX2NvZGUY",
@@ -46,72 +46,79 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
             "bl9jYXBhY2l0aWVzGBAgAygLMjguaW1wcm9iYWJsZS5zcGF0aWFsb3MuZGVw",
             "bG95bWVudC52MWFscGhhMS5Xb3JrZXJDYXBhY2l0eRJgCh13b3JrZXJfY29u",
             "bmVjdGlvbl9yYXRlX2xpbWl0cxgRIAMoCzI5LmltcHJvYmFibGUuc3BhdGlh",
-            "bG9zLmRlcGxveW1lbnQudjFhbHBoYTEuV29ya2VyUmF0ZUxpbWl0IloKBlN0",
-            "YXR1cxILCgdVTktOT1dOEAASDAoIU1RBUlRJTkcQZBIMCgdSVU5OSU5HEMgB",
-            "Eg0KCFNUT1BQSU5HEKwCEgwKB1NUT1BQRUQQkAMSCgoFRVJST1IQ9AMiaAoO",
-            "V29ya2VyQ2FwYWNpdHkSEwoLd29ya2VyX3R5cGUYASABKAkSJQoMbWF4X2Nh",
-            "cGFjaXR5GAIgASgFQg/i3x8LEP///////////wESGgoScmVtYWluaW5nX2Nh",
-            "cGFjaXR5GAMgASgFInEKD1dvcmtlclJhdGVMaW1pdBITCgt3b3JrZXJfdHlw",
-            "ZRgBIAEoCRIrCghkdXJhdGlvbhgCIAEoCzIZLmdvb2dsZS5wcm90b2J1Zi5E",
-            "dXJhdGlvbhIcChRyZXF1ZXN0c19pbl9kdXJhdGlvbhgDIAEoDSIjCgxMYXVu",
-            "Y2hDb25maWcSEwoLY29uZmlnX2pzb24YASABKAkiPQoKV29ya2VyRmxhZxIT",
-            "Cgt3b3JrZXJfdHlwZRgBIAEoCRILCgNrZXkYAiABKAkSDQoFdmFsdWUYAyAB",
-            "KAkiTAoKUGxheWVySW5mbxIWCg5hY3RpdmVfcGxheWVycxgBIAEoAxIQCghj",
-            "YXBhY2l0eRgCIAEoAxIUCgxxdWV1ZV9sZW5ndGgYAyABKAMi+AEKFkxpc3RE",
-            "ZXBsb3ltZW50c1JlcXVlc3QSLQoMcHJvamVjdF9uYW1lGAEgASgJQhfi3x8T",
-            "ChFeW2EtejAtOV9dezMsMzJ9JBIkCglwYWdlX3NpemUYAiABKAVCEeLfHw0Q",
-            "////////////ARgzEhIKCnBhZ2VfdG9rZW4YAyABKAkSMwoPZGVwbG95bWVu",
-            "dF9uYW1lGAQgASgJQhri3x8WChReJHxeW2EtejAtOV9dezMsMzJ9JBJACgR2",
-            "aWV3GAUgASgOMjIuaW1wcm9iYWJsZS5zcGF0aWFsb3MuZGVwbG95bWVudC52",
-            "MWFscGhhMS5WaWV3VHlwZSJ9ChdMaXN0RGVwbG95bWVudHNSZXNwb25zZRJJ",
-            "CgtkZXBsb3ltZW50cxgBIAMoCzI0LmltcHJvYmFibGUuc3BhdGlhbG9zLmRl",
-            "cGxveW1lbnQudjFhbHBoYTEuRGVwbG95bWVudBIXCg9uZXh0X3BhZ2VfdG9r",
-            "ZW4YAiABKAkiUQoUR2V0RGVwbG95bWVudFJlcXVlc3QSLQoMcHJvamVjdF9u",
-            "YW1lGAEgASgJQhfi3x8TChFeW2EtejAtOV9dezMsMzJ9JBIKCgJpZBgCIAEo",
-            "CSJhChVHZXREZXBsb3ltZW50UmVzcG9uc2USSAoKZGVwbG95bWVudBgBIAEo",
-            "CzI0LmltcHJvYmFibGUuc3BhdGlhbG9zLmRlcGxveW1lbnQudjFhbHBoYTEu",
-            "RGVwbG95bWVudCJrChdDcmVhdGVEZXBsb3ltZW50UmVxdWVzdBJQCgpkZXBs",
-            "b3ltZW50GAIgASgLMjQuaW1wcm9iYWJsZS5zcGF0aWFsb3MuZGVwbG95bWVu",
-            "dC52MWFscGhhMS5EZXBsb3ltZW50Qgbi3x8CIAEiGgoYQ3JlYXRlRGVwbG95",
-            "bWVudE1ldGFkYXRhIpwBChdVcGRhdGVEZXBsb3ltZW50UmVxdWVzdBJQCgpk",
-            "ZXBsb3ltZW50GAEgASgLMjQuaW1wcm9iYWJsZS5zcGF0aWFsb3MuZGVwbG95",
-            "bWVudC52MWFscGhhMS5EZXBsb3ltZW50Qgbi3x8CIAESLwoLdXBkYXRlX21h",
-            "c2sYAiABKAsyGi5nb29nbGUucHJvdG9idWYuRmllbGRNYXNrImQKGFVwZGF0",
-            "ZURlcGxveW1lbnRSZXNwb25zZRJICgpkZXBsb3ltZW50GAEgASgLMjQuaW1w",
-            "cm9iYWJsZS5zcGF0aWFsb3MuZGVwbG95bWVudC52MWFscGhhMS5EZXBsb3lt",
-            "ZW50IlIKFVN0b3BEZXBsb3ltZW50UmVxdWVzdBItCgxwcm9qZWN0X25hbWUY",
-            "ASABKAlCF+LfHxMKEV5bYS16MC05X117MywzMn0kEgoKAmlkGAIgASgJIhgK",
-            "FlN0b3BEZXBsb3ltZW50UmVzcG9uc2UqMAoIVmlld1R5cGUSDwoLVU5TUEVD",
-            "SUZJRUQQABIJCgVCQVNJQxABEggKBEZVTEwQAjLnBQoRRGVwbG95bWVudFNl",
-            "cnZpY2USlgEKD0xpc3REZXBsb3ltZW50cxJALmltcHJvYmFibGUuc3BhdGlh",
-            "bG9zLmRlcGxveW1lbnQudjFhbHBoYTEuTGlzdERlcGxveW1lbnRzUmVxdWVz",
-            "dBpBLmltcHJvYmFibGUuc3BhdGlhbG9zLmRlcGxveW1lbnQudjFhbHBoYTEu",
-            "TGlzdERlcGxveW1lbnRzUmVzcG9uc2USkAEKDUdldERlcGxveW1lbnQSPi5p",
-            "bXByb2JhYmxlLnNwYXRpYWxvcy5kZXBsb3ltZW50LnYxYWxwaGExLkdldERl",
-            "cGxveW1lbnRSZXF1ZXN0Gj8uaW1wcm9iYWJsZS5zcGF0aWFsb3MuZGVwbG95",
-            "bWVudC52MWFscGhhMS5HZXREZXBsb3ltZW50UmVzcG9uc2USdAoQQ3JlYXRl",
-            "RGVwbG95bWVudBJBLmltcHJvYmFibGUuc3BhdGlhbG9zLmRlcGxveW1lbnQu",
-            "djFhbHBoYTEuQ3JlYXRlRGVwbG95bWVudFJlcXVlc3QaHS5nb29nbGUubG9u",
-            "Z3J1bm5pbmcuT3BlcmF0aW9uEpkBChBVcGRhdGVEZXBsb3ltZW50EkEuaW1w",
+            "bG9zLmRlcGxveW1lbnQudjFhbHBoYTEuV29ya2VyUmF0ZUxpbWl0EhMKC2Rl",
+            "c2NyaXB0aW9uGBIgASgJEhcKD3J1bnRpbWVfdmVyc2lvbhgTIAEoCSJaCgZT",
+            "dGF0dXMSCwoHVU5LTk9XThAAEgwKCFNUQVJUSU5HEGQSDAoHUlVOTklORxDI",
+            "ARINCghTVE9QUElORxCsAhIMCgdTVE9QUEVEEJADEgoKBUVSUk9SEPQDImgK",
+            "DldvcmtlckNhcGFjaXR5EhMKC3dvcmtlcl90eXBlGAEgASgJEiUKDG1heF9j",
+            "YXBhY2l0eRgCIAEoBUIP4t8fCxD///////////8BEhoKEnJlbWFpbmluZ19j",
+            "YXBhY2l0eRgDIAEoBSJxCg9Xb3JrZXJSYXRlTGltaXQSEwoLd29ya2VyX3R5",
+            "cGUYASABKAkSKwoIZHVyYXRpb24YAiABKAsyGS5nb29nbGUucHJvdG9idWYu",
+            "RHVyYXRpb24SHAoUcmVxdWVzdHNfaW5fZHVyYXRpb24YAyABKA0iIwoMTGF1",
+            "bmNoQ29uZmlnEhMKC2NvbmZpZ19qc29uGAEgASgJIj0KCldvcmtlckZsYWcS",
+            "EwoLd29ya2VyX3R5cGUYASABKAkSCwoDa2V5GAIgASgJEg0KBXZhbHVlGAMg",
+            "ASgJIkwKClBsYXllckluZm8SFgoOYWN0aXZlX3BsYXllcnMYASABKAMSEAoI",
+            "Y2FwYWNpdHkYAiABKAMSFAoMcXVldWVfbGVuZ3RoGAMgASgDIu8DChZMaXN0",
+            "RGVwbG95bWVudHNSZXF1ZXN0Ei0KDHByb2plY3RfbmFtZRgBIAEoCUIX4t8f",
+            "EwoRXlthLXowLTlfXXszLDMyfSQSJAoJcGFnZV9zaXplGAIgASgFQhHi3x8N",
+            "EP///////////wEYMxISCgpwYWdlX3Rva2VuGAMgASgJEjMKD2RlcGxveW1l",
+            "bnRfbmFtZRgEIAEoCUIa4t8fFgoUXiR8XlthLXowLTlfXXszLDMyfSQSQAoE",
+            "dmlldxgFIAEoDjIyLmltcHJvYmFibGUuc3BhdGlhbG9zLmRlcGxveW1lbnQu",
+            "djFhbHBoYTEuVmlld1R5cGUSiAEKIGRlcGxveW1lbnRfc3RvcHBlZF9zdGF0",
+            "dXNfZmlsdGVyGAYgASgOMl4uaW1wcm9iYWJsZS5zcGF0aWFsb3MuZGVwbG95",
+            "bWVudC52MWFscGhhMS5MaXN0RGVwbG95bWVudHNSZXF1ZXN0LkRlcGxveW1l",
+            "bnRTdG9wcGVkU3RhdHVzRmlsdGVyImoKHURlcGxveW1lbnRTdG9wcGVkU3Rh",
+            "dHVzRmlsdGVyEhMKD0FMTF9ERVBMT1lNRU5UUxAAEhsKF05PVF9TVE9QUEVE",
+            "X0RFUExPWU1FTlRTEAESFwoTU1RPUFBFRF9ERVBMT1lNRU5UUxACIn0KF0xp",
+            "c3REZXBsb3ltZW50c1Jlc3BvbnNlEkkKC2RlcGxveW1lbnRzGAEgAygLMjQu",
+            "aW1wcm9iYWJsZS5zcGF0aWFsb3MuZGVwbG95bWVudC52MWFscGhhMS5EZXBs",
+            "b3ltZW50EhcKD25leHRfcGFnZV90b2tlbhgCIAEoCSJRChRHZXREZXBsb3lt",
+            "ZW50UmVxdWVzdBItCgxwcm9qZWN0X25hbWUYASABKAlCF+LfHxMKEV5bYS16",
+            "MC05X117MywzMn0kEgoKAmlkGAIgASgJImEKFUdldERlcGxveW1lbnRSZXNw",
+            "b25zZRJICgpkZXBsb3ltZW50GAEgASgLMjQuaW1wcm9iYWJsZS5zcGF0aWFs",
+            "b3MuZGVwbG95bWVudC52MWFscGhhMS5EZXBsb3ltZW50ImsKF0NyZWF0ZURl",
+            "cGxveW1lbnRSZXF1ZXN0ElAKCmRlcGxveW1lbnQYAiABKAsyNC5pbXByb2Jh",
+            "YmxlLnNwYXRpYWxvcy5kZXBsb3ltZW50LnYxYWxwaGExLkRlcGxveW1lbnRC",
+            "BuLfHwIgASIaChhDcmVhdGVEZXBsb3ltZW50TWV0YWRhdGEinAEKF1VwZGF0",
+            "ZURlcGxveW1lbnRSZXF1ZXN0ElAKCmRlcGxveW1lbnQYASABKAsyNC5pbXBy",
+            "b2JhYmxlLnNwYXRpYWxvcy5kZXBsb3ltZW50LnYxYWxwaGExLkRlcGxveW1l",
+            "bnRCBuLfHwIgARIvCgt1cGRhdGVfbWFzaxgCIAEoCzIaLmdvb2dsZS5wcm90",
+            "b2J1Zi5GaWVsZE1hc2siZAoYVXBkYXRlRGVwbG95bWVudFJlc3BvbnNlEkgK",
+            "CmRlcGxveW1lbnQYASABKAsyNC5pbXByb2JhYmxlLnNwYXRpYWxvcy5kZXBs",
+            "b3ltZW50LnYxYWxwaGExLkRlcGxveW1lbnQiUgoVU3RvcERlcGxveW1lbnRS",
+            "ZXF1ZXN0Ei0KDHByb2plY3RfbmFtZRgBIAEoCUIX4t8fEwoRXlthLXowLTlf",
+            "XXszLDMyfSQSCgoCaWQYAiABKAkiGAoWU3RvcERlcGxveW1lbnRSZXNwb25z",
+            "ZSowCghWaWV3VHlwZRIPCgtVTlNQRUNJRklFRBAAEgkKBUJBU0lDEAESCAoE",
+            "RlVMTBACMucFChFEZXBsb3ltZW50U2VydmljZRKWAQoPTGlzdERlcGxveW1l",
+            "bnRzEkAuaW1wcm9iYWJsZS5zcGF0aWFsb3MuZGVwbG95bWVudC52MWFscGhh",
+            "MS5MaXN0RGVwbG95bWVudHNSZXF1ZXN0GkEuaW1wcm9iYWJsZS5zcGF0aWFs",
+            "b3MuZGVwbG95bWVudC52MWFscGhhMS5MaXN0RGVwbG95bWVudHNSZXNwb25z",
+            "ZRKQAQoNR2V0RGVwbG95bWVudBI+LmltcHJvYmFibGUuc3BhdGlhbG9zLmRl",
+            "cGxveW1lbnQudjFhbHBoYTEuR2V0RGVwbG95bWVudFJlcXVlc3QaPy5pbXBy",
+            "b2JhYmxlLnNwYXRpYWxvcy5kZXBsb3ltZW50LnYxYWxwaGExLkdldERlcGxv",
+            "eW1lbnRSZXNwb25zZRJ0ChBDcmVhdGVEZXBsb3ltZW50EkEuaW1wcm9iYWJs",
+            "ZS5zcGF0aWFsb3MuZGVwbG95bWVudC52MWFscGhhMS5DcmVhdGVEZXBsb3lt",
+            "ZW50UmVxdWVzdBodLmdvb2dsZS5sb25ncnVubmluZy5PcGVyYXRpb24SmQEK",
+            "EFVwZGF0ZURlcGxveW1lbnQSQS5pbXByb2JhYmxlLnNwYXRpYWxvcy5kZXBs",
+            "b3ltZW50LnYxYWxwaGExLlVwZGF0ZURlcGxveW1lbnRSZXF1ZXN0GkIuaW1w",
             "cm9iYWJsZS5zcGF0aWFsb3MuZGVwbG95bWVudC52MWFscGhhMS5VcGRhdGVE",
-            "ZXBsb3ltZW50UmVxdWVzdBpCLmltcHJvYmFibGUuc3BhdGlhbG9zLmRlcGxv",
-            "eW1lbnQudjFhbHBoYTEuVXBkYXRlRGVwbG95bWVudFJlc3BvbnNlEpMBCg5T",
-            "dG9wRGVwbG95bWVudBI/LmltcHJvYmFibGUuc3BhdGlhbG9zLmRlcGxveW1l",
-            "bnQudjFhbHBoYTEuU3RvcERlcGxveW1lbnRSZXF1ZXN0GkAuaW1wcm9iYWJs",
-            "ZS5zcGF0aWFsb3MuZGVwbG95bWVudC52MWFscGhhMS5TdG9wRGVwbG95bWVu",
-            "dFJlc3BvbnNlQmBaM2ltcHJvYmFibGUvc3BhdGlhbG9zL2RlcGxveW1lbnQv",
-            "djFhbHBoYTE7ZGVwbG95bWVudKoCKEltcHJvYmFibGUuU3BhdGlhbE9TLkRl",
-            "cGxveW1lbnQuVjFBbHBoYTFiBnByb3RvMw=="));
+            "ZXBsb3ltZW50UmVzcG9uc2USkwEKDlN0b3BEZXBsb3ltZW50Ej8uaW1wcm9i",
+            "YWJsZS5zcGF0aWFsb3MuZGVwbG95bWVudC52MWFscGhhMS5TdG9wRGVwbG95",
+            "bWVudFJlcXVlc3QaQC5pbXByb2JhYmxlLnNwYXRpYWxvcy5kZXBsb3ltZW50",
+            "LnYxYWxwaGExLlN0b3BEZXBsb3ltZW50UmVzcG9uc2VCYFozaW1wcm9iYWJs",
+            "ZS9zcGF0aWFsb3MvZGVwbG95bWVudC92MWFscGhhMTtkZXBsb3ltZW50qgIo",
+            "SW1wcm9iYWJsZS5TcGF0aWFsT1MuRGVwbG95bWVudC5WMUFscGhhMWIGcHJv",
+            "dG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.LongRunning.OperationsReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.FieldMaskReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.DurationReflection.Descriptor, global::Validator.ValidatorReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.ViewType), }, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.Deployment), global::Improbable.SpatialOS.Deployment.V1Alpha1.Deployment.Parser, new[]{ "Id", "ProjectName", "Name", "RegionCode", "ClusterCode", "AssemblyId", "StartingSnapshotId", "Tag", "Status", "LaunchConfig", "WorkerFlags", "PlayerInfo", "StartTime", "StopTime", "WorkerConnectionCapacities", "WorkerConnectionRateLimits" }, null, new[]{ typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.Deployment.Types.Status) }, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.Deployment), global::Improbable.SpatialOS.Deployment.V1Alpha1.Deployment.Parser, new[]{ "Id", "ProjectName", "Name", "RegionCode", "ClusterCode", "AssemblyId", "StartingSnapshotId", "Tag", "Status", "LaunchConfig", "WorkerFlags", "PlayerInfo", "StartTime", "StopTime", "WorkerConnectionCapacities", "WorkerConnectionRateLimits", "Description", "RuntimeVersion" }, null, new[]{ typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.Deployment.Types.Status) }, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.WorkerCapacity), global::Improbable.SpatialOS.Deployment.V1Alpha1.WorkerCapacity.Parser, new[]{ "WorkerType", "MaxCapacity", "RemainingCapacity" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.WorkerRateLimit), global::Improbable.SpatialOS.Deployment.V1Alpha1.WorkerRateLimit.Parser, new[]{ "WorkerType", "Duration", "RequestsInDuration" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.LaunchConfig), global::Improbable.SpatialOS.Deployment.V1Alpha1.LaunchConfig.Parser, new[]{ "ConfigJson" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.WorkerFlag), global::Improbable.SpatialOS.Deployment.V1Alpha1.WorkerFlag.Parser, new[]{ "WorkerType", "Key", "Value" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.PlayerInfo), global::Improbable.SpatialOS.Deployment.V1Alpha1.PlayerInfo.Parser, new[]{ "ActivePlayers", "Capacity", "QueueLength" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.ListDeploymentsRequest), global::Improbable.SpatialOS.Deployment.V1Alpha1.ListDeploymentsRequest.Parser, new[]{ "ProjectName", "PageSize", "PageToken", "DeploymentName", "View" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.ListDeploymentsRequest), global::Improbable.SpatialOS.Deployment.V1Alpha1.ListDeploymentsRequest.Parser, new[]{ "ProjectName", "PageSize", "PageToken", "DeploymentName", "View", "DeploymentStoppedStatusFilter" }, null, new[]{ typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.ListDeploymentsRequest.Types.DeploymentStoppedStatusFilter) }, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.ListDeploymentsResponse), global::Improbable.SpatialOS.Deployment.V1Alpha1.ListDeploymentsResponse.Parser, new[]{ "Deployments", "NextPageToken" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.GetDeploymentRequest), global::Improbable.SpatialOS.Deployment.V1Alpha1.GetDeploymentRequest.Parser, new[]{ "ProjectName", "Id" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.Deployment.V1Alpha1.GetDeploymentResponse), global::Improbable.SpatialOS.Deployment.V1Alpha1.GetDeploymentResponse.Parser, new[]{ "Deployment" }, null, null, null),
@@ -150,9 +157,6 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
   #endregion
 
   #region Messages
-  /// <summary>
-  ///* A deployment of a game in the cloud. 
-  /// </summary>
   public sealed partial class Deployment : pb::IMessage<Deployment> {
     private static readonly pb::MessageParser<Deployment> _parser = new pb::MessageParser<Deployment>(() => new Deployment());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -193,6 +197,8 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       StopTime = other.stopTime_ != null ? other.StopTime.Clone() : null;
       workerConnectionCapacities_ = other.workerConnectionCapacities_.Clone();
       workerConnectionRateLimits_ = other.workerConnectionRateLimits_.Clone();
+      description_ = other.description_;
+      runtimeVersion_ = other.runtimeVersion_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -370,7 +376,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
     ///
     /// The worker flags that the deployment exposes at runtime.
     ///
-    /// Only applicable to running deployments.
+    /// Only applicable to running deployments. It is omitted for deployments of other states.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public pbc::RepeatedField<global::Improbable.SpatialOS.Deployment.V1Alpha1.WorkerFlag> WorkerFlags {
@@ -387,7 +393,8 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
     ///
     /// Information about the players participating in the deployment.
     ///
-    /// Only applicable to running deployments.
+    /// Only applicable to running deployments. It is omitted for deployments
+    /// of other states.
     /// </summary>
     [global::System.ObsoleteAttribute]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -469,6 +476,38 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       get { return workerConnectionRateLimits_; }
     }
 
+    /// <summary>Field number for the "description" field.</summary>
+    public const int DescriptionFieldNumber = 18;
+    private string description_ = "";
+    /// <summary>
+    /// Read-only
+    ///
+    /// The description provided when the deployment was started
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string Description {
+      get { return description_; }
+      set {
+        description_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "runtime_version" field.</summary>
+    public const int RuntimeVersionFieldNumber = 19;
+    private string runtimeVersion_ = "";
+    /// <summary>
+    /// Read-only
+    ///
+    /// The version of the Runtime used to start this deployment
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string RuntimeVersion {
+      get { return runtimeVersion_; }
+      set {
+        runtimeVersion_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Deployment);
@@ -498,6 +537,8 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       if (!object.Equals(StopTime, other.StopTime)) return false;
       if(!workerConnectionCapacities_.Equals(other.workerConnectionCapacities_)) return false;
       if(!workerConnectionRateLimits_.Equals(other.workerConnectionRateLimits_)) return false;
+      if (Description != other.Description) return false;
+      if (RuntimeVersion != other.RuntimeVersion) return false;
       return true;
     }
 
@@ -520,6 +561,8 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       if (stopTime_ != null) hash ^= StopTime.GetHashCode();
       hash ^= workerConnectionCapacities_.GetHashCode();
       hash ^= workerConnectionRateLimits_.GetHashCode();
+      if (Description.Length != 0) hash ^= Description.GetHashCode();
+      if (RuntimeVersion.Length != 0) hash ^= RuntimeVersion.GetHashCode();
       return hash;
     }
 
@@ -582,6 +625,14 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
       workerConnectionCapacities_.WriteTo(output, _repeated_workerConnectionCapacities_codec);
       workerConnectionRateLimits_.WriteTo(output, _repeated_workerConnectionRateLimits_codec);
+      if (Description.Length != 0) {
+        output.WriteRawTag(146, 1);
+        output.WriteString(Description);
+      }
+      if (RuntimeVersion.Length != 0) {
+        output.WriteRawTag(154, 1);
+        output.WriteString(RuntimeVersion);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -627,6 +678,12 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
       size += workerConnectionCapacities_.CalculateSize(_repeated_workerConnectionCapacities_codec);
       size += workerConnectionRateLimits_.CalculateSize(_repeated_workerConnectionRateLimits_codec);
+      if (Description.Length != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeStringSize(Description);
+      }
+      if (RuntimeVersion.Length != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeStringSize(RuntimeVersion);
+      }
       return size;
     }
 
@@ -687,6 +744,12 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
       workerConnectionCapacities_.Add(other.workerConnectionCapacities_);
       workerConnectionRateLimits_.Add(other.workerConnectionRateLimits_);
+      if (other.Description.Length != 0) {
+        Description = other.Description;
+      }
+      if (other.RuntimeVersion.Length != 0) {
+        RuntimeVersion = other.RuntimeVersion;
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -771,6 +834,14 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
           }
           case 138: {
             workerConnectionRateLimits_.AddEntriesFrom(input, _repeated_workerConnectionRateLimits_codec);
+            break;
+          }
+          case 146: {
+            Description = input.ReadString();
+            break;
+          }
+          case 154: {
+            RuntimeVersion = input.ReadString();
             break;
           }
         }
@@ -1694,6 +1765,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       pageToken_ = other.pageToken_;
       deploymentName_ = other.deploymentName_;
       view_ = other.view_;
+      deploymentStoppedStatusFilter_ = other.deploymentStoppedStatusFilter_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1781,6 +1853,20 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
     }
 
+    /// <summary>Field number for the "deployment_stopped_status_filter" field.</summary>
+    public const int DeploymentStoppedStatusFilterFieldNumber = 6;
+    private global::Improbable.SpatialOS.Deployment.V1Alpha1.ListDeploymentsRequest.Types.DeploymentStoppedStatusFilter deploymentStoppedStatusFilter_ = 0;
+    /// <summary>
+    /// Filter for all deployments, deployments that are stopped or deployments that are not stopped.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Improbable.SpatialOS.Deployment.V1Alpha1.ListDeploymentsRequest.Types.DeploymentStoppedStatusFilter DeploymentStoppedStatusFilter {
+      get { return deploymentStoppedStatusFilter_; }
+      set {
+        deploymentStoppedStatusFilter_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ListDeploymentsRequest);
@@ -1799,6 +1885,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       if (PageToken != other.PageToken) return false;
       if (DeploymentName != other.DeploymentName) return false;
       if (View != other.View) return false;
+      if (DeploymentStoppedStatusFilter != other.DeploymentStoppedStatusFilter) return false;
       return true;
     }
 
@@ -1810,6 +1897,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       if (PageToken.Length != 0) hash ^= PageToken.GetHashCode();
       if (DeploymentName.Length != 0) hash ^= DeploymentName.GetHashCode();
       if (View != 0) hash ^= View.GetHashCode();
+      if (DeploymentStoppedStatusFilter != 0) hash ^= DeploymentStoppedStatusFilter.GetHashCode();
       return hash;
     }
 
@@ -1840,6 +1928,10 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
         output.WriteRawTag(40);
         output.WriteEnum((int) View);
       }
+      if (DeploymentStoppedStatusFilter != 0) {
+        output.WriteRawTag(48);
+        output.WriteEnum((int) DeploymentStoppedStatusFilter);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1859,6 +1951,9 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
       if (View != 0) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) View);
+      }
+      if (DeploymentStoppedStatusFilter != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) DeploymentStoppedStatusFilter);
       }
       return size;
     }
@@ -1882,6 +1977,9 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
       if (other.View != 0) {
         View = other.View;
+      }
+      if (other.DeploymentStoppedStatusFilter != 0) {
+        DeploymentStoppedStatusFilter = other.DeploymentStoppedStatusFilter;
       }
     }
 
@@ -1913,9 +2011,26 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
             view_ = (global::Improbable.SpatialOS.Deployment.V1Alpha1.ViewType) input.ReadEnum();
             break;
           }
+          case 48: {
+            deploymentStoppedStatusFilter_ = (global::Improbable.SpatialOS.Deployment.V1Alpha1.ListDeploymentsRequest.Types.DeploymentStoppedStatusFilter) input.ReadEnum();
+            break;
+          }
         }
       }
     }
+
+    #region Nested types
+    /// <summary>Container for nested types declared in the ListDeploymentsRequest message type.</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static partial class Types {
+      public enum DeploymentStoppedStatusFilter {
+        [pbr::OriginalName("ALL_DEPLOYMENTS")] AllDeployments = 0,
+        [pbr::OriginalName("NOT_STOPPED_DEPLOYMENTS")] NotStoppedDeployments = 1,
+        [pbr::OriginalName("STOPPED_DEPLOYMENTS")] StoppedDeployments = 2,
+      }
+
+    }
+    #endregion
 
   }
 
@@ -2374,7 +2489,25 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
     /// <summary>
     /// The deployment to start.
     ///
-    /// You can only supply fields that are mutable at the point when you start the deployment.
+    /// These fields are mandatory:
+    /// `name`
+    /// `project_name`
+    /// `assembly_id`
+    /// `starting_snapshot_id`
+    /// `launch_config`
+    ///
+    /// In addition, these fields are optional:
+    /// `region_code`
+    /// `cluster_code`
+    /// `tag`
+    ///
+    /// These fields are ignored:
+    /// `worker_flags`
+    /// `worker_connection_capacities`
+    /// `worker_connection_rate_limits`
+    ///
+    /// For `worker_flags`, `worker_connection_capacities`, and `worker_connection_rate_limits`,
+    /// set their values in the launch configuration JSON file instead.
     ///
     /// Non-empty read-only fields passed in will be ignored.
     /// </summary>
@@ -2467,7 +2600,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
   }
 
   /// <summary>
-  /// For internal use only
+  /// Metadata for CreateDeployment operations.
   /// </summary>
   public sealed partial class CreateDeploymentMetadata : pb::IMessage<CreateDeploymentMetadata> {
     private static readonly pb::MessageParser<CreateDeploymentMetadata> _parser = new pb::MessageParser<CreateDeploymentMetadata>(() => new CreateDeploymentMetadata());
@@ -2594,6 +2727,20 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
     /// <summary>Field number for the "deployment" field.</summary>
     public const int DeploymentFieldNumber = 1;
     private global::Improbable.SpatialOS.Deployment.V1Alpha1.Deployment deployment_;
+    /// <summary>
+    /// The deployment to update.
+    ///
+    /// These fields are mandatory:
+    /// `id`
+    ///
+    /// These fields are mutable:
+    /// `tag`
+    /// `worker_flags`
+    /// `worker_connection_capacities`
+    /// `worker_connection_rate_limits`
+    ///
+    /// The request ignores any immutable fields that you've changed.
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Improbable.SpatialOS.Deployment.V1Alpha1.Deployment Deployment {
       get { return deployment_; }
@@ -2606,10 +2753,21 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
     public const int UpdateMaskFieldNumber = 2;
     private global::Google.Protobuf.WellKnownTypes.FieldMask updateMask_;
     /// <summary>
-    /// A mask which you can provide for partial updates of the resource.
-    /// Only the fields specified in the mask are modified on the response.
+    /// Use `update_mask` to provide partial object updates.
     ///
-    /// Further Documentation:
+    /// We only support these fields, as in the proto serialised way:
+    /// `tag`
+    /// `worker_flags`
+    /// `worker_connection_capacities`
+    /// `worker_connection_rate_limits`
+    ///
+    /// This RPC adopts two FieldMask specifics:
+    /// - Having an empty `update_mask` (not setting an array, or setting an empty array) updates all mutable fields.
+    /// - It ignores valid (mappable) paths to immutable fields.
+    /// - Invalid (un-mappable) or duplicated `update_masks` return an `INVALID_ARGUMENT` error.
+    /// For example, an empty path `` is invalid as it doesn't map to any field.
+    ///
+    /// Further Documentation on FieldMask:
     /// https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/apis/deployment_v1alpha1/DeploymentGrpc.cs
+++ b/apis/deployment_v1alpha1/DeploymentGrpc.cs
@@ -75,7 +75,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
     public abstract partial class DeploymentServiceBase
     {
       /// <summary>
-      /// Returns information about each running deployment for a given project.
+      /// Lists deployments under a given project.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -87,9 +87,6 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
 
       /// <summary>
       /// Gets a deployment as identified by `id`.
-      ///
-      /// For the `player_info` and `worker_flags` fields:
-      /// - Stopped deployments return default zero values in the client's programming language.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -102,27 +99,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       /// <summary>
       /// Creates a deployment.
       ///
-      /// These fields are mandatory:
-      /// `name`
-      /// `project_name`
-      /// `assembly_id`
-      /// `starting_snapshot_id`
-      /// `launch_config`
-      ///
-      /// In addition, these fields are optional:
-      /// `region_code`
-      /// `cluster_code`
-      /// `tag`
-      ///
-      /// These fields are ignored:
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// For `worker_flags`, `worker_connection_capacities`, and `worker_connection_rate_limits`,
-      /// set their values in the launch configuration JSON file instead.
-      ///
-      /// The returned operation result is of type `deployment`.
+      /// The returned operation result is of type `deployment` upon successful creation.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -133,32 +110,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
 
       /// <summary>
-      /// Updates a deployment, running or stopped, as specified by the deployment's `id`.
-      ///
-      /// Only these fields are mutable:
-      /// `tag`
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// The request ignores any immutable fields that you've changed.
-      ///
-      /// In addition, these fields are mandatory:
-      /// `id` field in `deployment`
-      ///
-      /// Use `update_mask` to provide partial updates
-      ///
-      /// We only support these paths, as in the proto serialised way:
-      /// `tag`
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// This RPC adopts two FieldMask specifics:
-      /// - Having an empty `update_mask` (not setting an array, or setting an empty array) updates all mutable fields.
-      /// - It ignores valid (mappable) paths to immutable fields.
-      /// - Invalid (unmappable) or duplicated `update_masks` return an `INVALID_ARGUMENT` error.
-      /// For example, an empty path `` is invalid as it doesn't map to any field.
+      /// Updates a deployment as identified by the deployment's `id`.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -205,7 +157,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
 
       /// <summary>
-      /// Returns information about each running deployment for a given project.
+      /// Lists deployments under a given project.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -217,7 +169,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
         return ListDeployments(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Returns information about each running deployment for a given project.
+      /// Lists deployments under a given project.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -227,7 +179,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
         return CallInvoker.BlockingUnaryCall(__Method_ListDeployments, null, options, request);
       }
       /// <summary>
-      /// Returns information about each running deployment for a given project.
+      /// Lists deployments under a given project.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -239,7 +191,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
         return ListDeploymentsAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Returns information about each running deployment for a given project.
+      /// Lists deployments under a given project.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -250,9 +202,6 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
       /// <summary>
       /// Gets a deployment as identified by `id`.
-      ///
-      /// For the `player_info` and `worker_flags` fields:
-      /// - Stopped deployments return default zero values in the client's programming language.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -265,9 +214,6 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
       /// <summary>
       /// Gets a deployment as identified by `id`.
-      ///
-      /// For the `player_info` and `worker_flags` fields:
-      /// - Stopped deployments return default zero values in the client's programming language.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -278,9 +224,6 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
       /// <summary>
       /// Gets a deployment as identified by `id`.
-      ///
-      /// For the `player_info` and `worker_flags` fields:
-      /// - Stopped deployments return default zero values in the client's programming language.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -293,9 +236,6 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       }
       /// <summary>
       /// Gets a deployment as identified by `id`.
-      ///
-      /// For the `player_info` and `worker_flags` fields:
-      /// - Stopped deployments return default zero values in the client's programming language.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -307,27 +247,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       /// <summary>
       /// Creates a deployment.
       ///
-      /// These fields are mandatory:
-      /// `name`
-      /// `project_name`
-      /// `assembly_id`
-      /// `starting_snapshot_id`
-      /// `launch_config`
-      ///
-      /// In addition, these fields are optional:
-      /// `region_code`
-      /// `cluster_code`
-      /// `tag`
-      ///
-      /// These fields are ignored:
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// For `worker_flags`, `worker_connection_capacities`, and `worker_connection_rate_limits`,
-      /// set their values in the launch configuration JSON file instead.
-      ///
-      /// The returned operation result is of type `deployment`.
+      /// The returned operation result is of type `deployment` upon successful creation.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -341,27 +261,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       /// <summary>
       /// Creates a deployment.
       ///
-      /// These fields are mandatory:
-      /// `name`
-      /// `project_name`
-      /// `assembly_id`
-      /// `starting_snapshot_id`
-      /// `launch_config`
-      ///
-      /// In addition, these fields are optional:
-      /// `region_code`
-      /// `cluster_code`
-      /// `tag`
-      ///
-      /// These fields are ignored:
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// For `worker_flags`, `worker_connection_capacities`, and `worker_connection_rate_limits`,
-      /// set their values in the launch configuration JSON file instead.
-      ///
-      /// The returned operation result is of type `deployment`.
+      /// The returned operation result is of type `deployment` upon successful creation.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -373,27 +273,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       /// <summary>
       /// Creates a deployment.
       ///
-      /// These fields are mandatory:
-      /// `name`
-      /// `project_name`
-      /// `assembly_id`
-      /// `starting_snapshot_id`
-      /// `launch_config`
-      ///
-      /// In addition, these fields are optional:
-      /// `region_code`
-      /// `cluster_code`
-      /// `tag`
-      ///
-      /// These fields are ignored:
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// For `worker_flags`, `worker_connection_capacities`, and `worker_connection_rate_limits`,
-      /// set their values in the launch configuration JSON file instead.
-      ///
-      /// The returned operation result is of type `deployment`.
+      /// The returned operation result is of type `deployment` upon successful creation.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -407,27 +287,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
       /// <summary>
       /// Creates a deployment.
       ///
-      /// These fields are mandatory:
-      /// `name`
-      /// `project_name`
-      /// `assembly_id`
-      /// `starting_snapshot_id`
-      /// `launch_config`
-      ///
-      /// In addition, these fields are optional:
-      /// `region_code`
-      /// `cluster_code`
-      /// `tag`
-      ///
-      /// These fields are ignored:
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// For `worker_flags`, `worker_connection_capacities`, and `worker_connection_rate_limits`,
-      /// set their values in the launch configuration JSON file instead.
-      ///
-      /// The returned operation result is of type `deployment`.
+      /// The returned operation result is of type `deployment` upon successful creation.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -437,32 +297,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
         return CallInvoker.AsyncUnaryCall(__Method_CreateDeployment, null, options, request);
       }
       /// <summary>
-      /// Updates a deployment, running or stopped, as specified by the deployment's `id`.
-      ///
-      /// Only these fields are mutable:
-      /// `tag`
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// The request ignores any immutable fields that you've changed.
-      ///
-      /// In addition, these fields are mandatory:
-      /// `id` field in `deployment`
-      ///
-      /// Use `update_mask` to provide partial updates
-      ///
-      /// We only support these paths, as in the proto serialised way:
-      /// `tag`
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// This RPC adopts two FieldMask specifics:
-      /// - Having an empty `update_mask` (not setting an array, or setting an empty array) updates all mutable fields.
-      /// - It ignores valid (mappable) paths to immutable fields.
-      /// - Invalid (unmappable) or duplicated `update_masks` return an `INVALID_ARGUMENT` error.
-      /// For example, an empty path `` is invalid as it doesn't map to any field.
+      /// Updates a deployment as identified by the deployment's `id`.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -474,32 +309,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
         return UpdateDeployment(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Updates a deployment, running or stopped, as specified by the deployment's `id`.
-      ///
-      /// Only these fields are mutable:
-      /// `tag`
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// The request ignores any immutable fields that you've changed.
-      ///
-      /// In addition, these fields are mandatory:
-      /// `id` field in `deployment`
-      ///
-      /// Use `update_mask` to provide partial updates
-      ///
-      /// We only support these paths, as in the proto serialised way:
-      /// `tag`
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// This RPC adopts two FieldMask specifics:
-      /// - Having an empty `update_mask` (not setting an array, or setting an empty array) updates all mutable fields.
-      /// - It ignores valid (mappable) paths to immutable fields.
-      /// - Invalid (unmappable) or duplicated `update_masks` return an `INVALID_ARGUMENT` error.
-      /// For example, an empty path `` is invalid as it doesn't map to any field.
+      /// Updates a deployment as identified by the deployment's `id`.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -509,32 +319,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
         return CallInvoker.BlockingUnaryCall(__Method_UpdateDeployment, null, options, request);
       }
       /// <summary>
-      /// Updates a deployment, running or stopped, as specified by the deployment's `id`.
-      ///
-      /// Only these fields are mutable:
-      /// `tag`
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// The request ignores any immutable fields that you've changed.
-      ///
-      /// In addition, these fields are mandatory:
-      /// `id` field in `deployment`
-      ///
-      /// Use `update_mask` to provide partial updates
-      ///
-      /// We only support these paths, as in the proto serialised way:
-      /// `tag`
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// This RPC adopts two FieldMask specifics:
-      /// - Having an empty `update_mask` (not setting an array, or setting an empty array) updates all mutable fields.
-      /// - It ignores valid (mappable) paths to immutable fields.
-      /// - Invalid (unmappable) or duplicated `update_masks` return an `INVALID_ARGUMENT` error.
-      /// For example, an empty path `` is invalid as it doesn't map to any field.
+      /// Updates a deployment as identified by the deployment's `id`.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -546,32 +331,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
         return UpdateDeploymentAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Updates a deployment, running or stopped, as specified by the deployment's `id`.
-      ///
-      /// Only these fields are mutable:
-      /// `tag`
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// The request ignores any immutable fields that you've changed.
-      ///
-      /// In addition, these fields are mandatory:
-      /// `id` field in `deployment`
-      ///
-      /// Use `update_mask` to provide partial updates
-      ///
-      /// We only support these paths, as in the proto serialised way:
-      /// `tag`
-      /// `worker_flags`
-      /// `worker_connection_capacities`
-      /// `worker_connection_rate_limits`
-      ///
-      /// This RPC adopts two FieldMask specifics:
-      /// - Having an empty `update_mask` (not setting an array, or setting an empty array) updates all mutable fields.
-      /// - It ignores valid (mappable) paths to immutable fields.
-      /// - Invalid (unmappable) or duplicated `update_masks` return an `INVALID_ARGUMENT` error.
-      /// For example, an empty path `` is invalid as it doesn't map to any field.
+      /// Updates a deployment as identified by the deployment's `id`.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>

--- a/apis/playerauth_v2alpha1/PlayerAuth.cs
+++ b/apis/playerauth_v2alpha1/PlayerAuth.cs
@@ -59,72 +59,72 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
             "RGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2VuUmVxdWVzdBIyCgxwcm9q",
             "ZWN0X25hbWUYASABKAlCHOLfHxgKFF5bYS16QS1aMC05X117MywzMn0kIAES",
             "GwoLZGVzY3JpcHRpb24YAiABKAlCBuLfHwJYARIrCghsaWZldGltZRgDIAEo",
-            "CzIZLmdvb2dsZS5wcm90b2J1Zi5EdXJhdGlvbiKiAQosQ3JlYXRlRGV2ZWxv",
+            "CzIZLmdvb2dsZS5wcm90b2J1Zi5EdXJhdGlvbiK4AQosQ3JlYXRlRGV2ZWxv",
             "cG1lbnRBdXRoZW50aWNhdGlvblRva2VuUmVzcG9uc2UScgogZGV2ZWxvcG1l",
             "bnRfYXV0aGVudGljYXRpb25fdG9rZW4YASABKAsySC5pbXByb2JhYmxlLnNw",
             "YXRpYWxvcy5wbGF5ZXJhdXRoLnYyYWxwaGExLkRldmVsb3BtZW50QXV0aGVu",
-            "dGljYXRpb25Ub2tlbiI+CihHZXREZXZlbG9wbWVudEF1dGhlbnRpY2F0aW9u",
-            "VG9rZW5SZXF1ZXN0EhIKAmlkGAEgASgJQgbi3x8CWAEinwEKKUdldERldmVs",
-            "b3BtZW50QXV0aGVudGljYXRpb25Ub2tlblJlc3BvbnNlEnIKIGRldmVsb3Bt",
-            "ZW50X2F1dGhlbnRpY2F0aW9uX3Rva2VuGAEgASgLMkguaW1wcm9iYWJsZS5z",
-            "cGF0aWFsb3MucGxheWVyYXV0aC52MmFscGhhMS5EZXZlbG9wbWVudEF1dGhl",
-            "bnRpY2F0aW9uVG9rZW4iswEKKkxpc3REZXZlbG9wbWVudEF1dGhlbnRpY2F0",
-            "aW9uVG9rZW5zUmVxdWVzdBIyCgxwcm9qZWN0X25hbWUYASABKAlCHOLfHxgK",
-            "FF5bYS16QS1aMC05X117MywzMn0kIAESFwoPaW5jbHVkZV9leHBpcmVkGAIg",
-            "ASgIEiQKCXBhZ2Vfc2l6ZRgDIAEoBUIR4t8fDRD///////////8BGDMSEgoK",
-            "cGFnZV90b2tlbhgEIAEoCSK7AQorTGlzdERldmVsb3BtZW50QXV0aGVudGlj",
-            "YXRpb25Ub2tlbnNSZXNwb25zZRJzCiFkZXZlbG9wbWVudF9hdXRoZW50aWNh",
-            "dGlvbl90b2tlbnMYASADKAsySC5pbXByb2JhYmxlLnNwYXRpYWxvcy5wbGF5",
-            "ZXJhdXRoLnYyYWxwaGExLkRldmVsb3BtZW50QXV0aGVudGljYXRpb25Ub2tl",
-            "bhIXCg9uZXh0X3BhZ2VfdG9rZW4YAiABKAkiiwEKK1VwZGF0ZURldmVsb3Bt",
-            "ZW50QXV0aGVudGljYXRpb25Ub2tlblJlcXVlc3QSEgoCaWQYASABKAlCBuLf",
-            "HwJYARITCgtkZXNjcmlwdGlvbhgCIAEoCRIzChB1cGRhdGVkX2xpZmV0aW1l",
-            "GAMgASgLMhkuZ29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uIqIBCixVcGRhdGVE",
-            "ZXZlbG9wbWVudEF1dGhlbnRpY2F0aW9uVG9rZW5SZXNwb25zZRJyCiBkZXZl",
-            "bG9wbWVudF9hdXRoZW50aWNhdGlvbl90b2tlbhgBIAEoCzJILmltcHJvYmFi",
-            "bGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBoYTEuRGV2ZWxvcG1lbnRB",
-            "dXRoZW50aWNhdGlvblRva2VuIkEKK0V4cGlyZURldmVsb3BtZW50QXV0aGVu",
-            "dGljYXRpb25Ub2tlblJlcXVlc3QSEgoCaWQYASABKAlCBuLfHwJYASIuCixF",
-            "eHBpcmVEZXZlbG9wbWVudEF1dGhlbnRpY2F0aW9uVG9rZW5SZXNwb25zZTLJ",
-            "DAoRUGxheWVyQXV0aFNlcnZpY2USmQEKEENyZWF0ZUxvZ2luVG9rZW4SQS5p",
-            "bXByb2JhYmxlLnNwYXRpYWxvcy5wbGF5ZXJhdXRoLnYyYWxwaGExLkNyZWF0",
-            "ZUxvZ2luVG9rZW5SZXF1ZXN0GkIuaW1wcm9iYWJsZS5zcGF0aWFsb3MucGxh",
-            "eWVyYXV0aC52MmFscGhhMS5DcmVhdGVMb2dpblRva2VuUmVzcG9uc2UStAEK",
-            "GUNyZWF0ZVBsYXllcklkZW50aXR5VG9rZW4SSi5pbXByb2JhYmxlLnNwYXRp",
-            "YWxvcy5wbGF5ZXJhdXRoLnYyYWxwaGExLkNyZWF0ZVBsYXllcklkZW50aXR5",
-            "VG9rZW5SZXF1ZXN0GksuaW1wcm9iYWJsZS5zcGF0aWFsb3MucGxheWVyYXV0",
-            "aC52MmFscGhhMS5DcmVhdGVQbGF5ZXJJZGVudGl0eVRva2VuUmVzcG9uc2US",
-            "tAEKGURlY29kZVBsYXllcklkZW50aXR5VG9rZW4SSi5pbXByb2JhYmxlLnNw",
-            "YXRpYWxvcy5wbGF5ZXJhdXRoLnYyYWxwaGExLkRlY29kZVBsYXllcklkZW50",
-            "aXR5VG9rZW5SZXF1ZXN0GksuaW1wcm9iYWJsZS5zcGF0aWFsb3MucGxheWVy",
-            "YXV0aC52MmFscGhhMS5EZWNvZGVQbGF5ZXJJZGVudGl0eVRva2VuUmVzcG9u",
-            "c2US1QEKJENyZWF0ZURldmVsb3BtZW50QXV0aGVudGljYXRpb25Ub2tlbhJV",
-            "LmltcHJvYmFibGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBoYTEuQ3Jl",
-            "YXRlRGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2VuUmVxdWVzdBpWLmlt",
+            "dGljYXRpb25Ub2tlbhIUCgx0b2tlbl9zZWNyZXQYAiABKAkiPgooR2V0RGV2",
+            "ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2VuUmVxdWVzdBISCgJpZBgBIAEo",
+            "CUIG4t8fAlgBIp8BCilHZXREZXZlbG9wbWVudEF1dGhlbnRpY2F0aW9uVG9r",
+            "ZW5SZXNwb25zZRJyCiBkZXZlbG9wbWVudF9hdXRoZW50aWNhdGlvbl90b2tl",
+            "bhgBIAEoCzJILmltcHJvYmFibGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJh",
+            "bHBoYTEuRGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2VuIrMBCipMaXN0",
+            "RGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2Vuc1JlcXVlc3QSMgoMcHJv",
+            "amVjdF9uYW1lGAEgASgJQhzi3x8YChReW2EtekEtWjAtOV9dezMsMzJ9JCAB",
+            "EhcKD2luY2x1ZGVfZXhwaXJlZBgCIAEoCBIkCglwYWdlX3NpemUYAyABKAVC",
+            "EeLfHw0Q////////////ARgzEhIKCnBhZ2VfdG9rZW4YBCABKAkiuwEKK0xp",
+            "c3REZXZlbG9wbWVudEF1dGhlbnRpY2F0aW9uVG9rZW5zUmVzcG9uc2UScwoh",
+            "ZGV2ZWxvcG1lbnRfYXV0aGVudGljYXRpb25fdG9rZW5zGAEgAygLMkguaW1w",
+            "cm9iYWJsZS5zcGF0aWFsb3MucGxheWVyYXV0aC52MmFscGhhMS5EZXZlbG9w",
+            "bWVudEF1dGhlbnRpY2F0aW9uVG9rZW4SFwoPbmV4dF9wYWdlX3Rva2VuGAIg",
+            "ASgJIosBCitVcGRhdGVEZXZlbG9wbWVudEF1dGhlbnRpY2F0aW9uVG9rZW5S",
+            "ZXF1ZXN0EhIKAmlkGAEgASgJQgbi3x8CWAESEwoLZGVzY3JpcHRpb24YAiAB",
+            "KAkSMwoQdXBkYXRlZF9saWZldGltZRgDIAEoCzIZLmdvb2dsZS5wcm90b2J1",
+            "Zi5EdXJhdGlvbiKiAQosVXBkYXRlRGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlv",
+            "blRva2VuUmVzcG9uc2UScgogZGV2ZWxvcG1lbnRfYXV0aGVudGljYXRpb25f",
+            "dG9rZW4YASABKAsySC5pbXByb2JhYmxlLnNwYXRpYWxvcy5wbGF5ZXJhdXRo",
+            "LnYyYWxwaGExLkRldmVsb3BtZW50QXV0aGVudGljYXRpb25Ub2tlbiJBCitF",
+            "eHBpcmVEZXZlbG9wbWVudEF1dGhlbnRpY2F0aW9uVG9rZW5SZXF1ZXN0EhIK",
+            "AmlkGAEgASgJQgbi3x8CWAEiLgosRXhwaXJlRGV2ZWxvcG1lbnRBdXRoZW50",
+            "aWNhdGlvblRva2VuUmVzcG9uc2UyyQwKEVBsYXllckF1dGhTZXJ2aWNlEpkB",
+            "ChBDcmVhdGVMb2dpblRva2VuEkEuaW1wcm9iYWJsZS5zcGF0aWFsb3MucGxh",
+            "eWVyYXV0aC52MmFscGhhMS5DcmVhdGVMb2dpblRva2VuUmVxdWVzdBpCLmlt",
             "cHJvYmFibGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBoYTEuQ3JlYXRl",
-            "RGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2VuUmVzcG9uc2USzAEKIUdl",
-            "dERldmVsb3BtZW50QXV0aGVudGljYXRpb25Ub2tlbhJSLmltcHJvYmFibGUu",
-            "c3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBoYTEuR2V0RGV2ZWxvcG1lbnRB",
-            "dXRoZW50aWNhdGlvblRva2VuUmVxdWVzdBpTLmltcHJvYmFibGUuc3BhdGlh",
-            "bG9zLnBsYXllcmF1dGgudjJhbHBoYTEuR2V0RGV2ZWxvcG1lbnRBdXRoZW50",
-            "aWNhdGlvblRva2VuUmVzcG9uc2US0gEKI0xpc3REZXZlbG9wbWVudEF1dGhl",
-            "bnRpY2F0aW9uVG9rZW5zElQuaW1wcm9iYWJsZS5zcGF0aWFsb3MucGxheWVy",
-            "YXV0aC52MmFscGhhMS5MaXN0RGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRv",
-            "a2Vuc1JlcXVlc3QaVS5pbXByb2JhYmxlLnNwYXRpYWxvcy5wbGF5ZXJhdXRo",
-            "LnYyYWxwaGExLkxpc3REZXZlbG9wbWVudEF1dGhlbnRpY2F0aW9uVG9rZW5z",
-            "UmVzcG9uc2US1QEKJFVwZGF0ZURldmVsb3BtZW50QXV0aGVudGljYXRpb25U",
-            "b2tlbhJVLmltcHJvYmFibGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBo",
-            "YTEuVXBkYXRlRGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2VuUmVxdWVz",
-            "dBpWLmltcHJvYmFibGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBoYTEu",
-            "VXBkYXRlRGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2VuUmVzcG9uc2US",
-            "1QEKJEV4cGlyZURldmVsb3BtZW50QXV0aGVudGljYXRpb25Ub2tlbhJVLmlt",
-            "cHJvYmFibGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBoYTEuRXhwaXJl",
-            "RGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2VuUmVxdWVzdBpWLmltcHJv",
-            "YmFibGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBoYTEuRXhwaXJlRGV2",
-            "ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2VuUmVzcG9uc2VCYFozaW1wcm9i",
-            "YWJsZS9zcGF0aWFsb3MvcGxheWVyYXV0aC92MmFscGhhMTtwbGF5ZXJhdXRo",
-            "qgIoSW1wcm9iYWJsZS5TcGF0aWFsT1MuUGxheWVyQXV0aC5WMkFscGhhMWIG",
-            "cHJvdG8z"));
+            "TG9naW5Ub2tlblJlc3BvbnNlErQBChlDcmVhdGVQbGF5ZXJJZGVudGl0eVRv",
+            "a2VuEkouaW1wcm9iYWJsZS5zcGF0aWFsb3MucGxheWVyYXV0aC52MmFscGhh",
+            "MS5DcmVhdGVQbGF5ZXJJZGVudGl0eVRva2VuUmVxdWVzdBpLLmltcHJvYmFi",
+            "bGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBoYTEuQ3JlYXRlUGxheWVy",
+            "SWRlbnRpdHlUb2tlblJlc3BvbnNlErQBChlEZWNvZGVQbGF5ZXJJZGVudGl0",
+            "eVRva2VuEkouaW1wcm9iYWJsZS5zcGF0aWFsb3MucGxheWVyYXV0aC52MmFs",
+            "cGhhMS5EZWNvZGVQbGF5ZXJJZGVudGl0eVRva2VuUmVxdWVzdBpLLmltcHJv",
+            "YmFibGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBoYTEuRGVjb2RlUGxh",
+            "eWVySWRlbnRpdHlUb2tlblJlc3BvbnNlEtUBCiRDcmVhdGVEZXZlbG9wbWVu",
+            "dEF1dGhlbnRpY2F0aW9uVG9rZW4SVS5pbXByb2JhYmxlLnNwYXRpYWxvcy5w",
+            "bGF5ZXJhdXRoLnYyYWxwaGExLkNyZWF0ZURldmVsb3BtZW50QXV0aGVudGlj",
+            "YXRpb25Ub2tlblJlcXVlc3QaVi5pbXByb2JhYmxlLnNwYXRpYWxvcy5wbGF5",
+            "ZXJhdXRoLnYyYWxwaGExLkNyZWF0ZURldmVsb3BtZW50QXV0aGVudGljYXRp",
+            "b25Ub2tlblJlc3BvbnNlEswBCiFHZXREZXZlbG9wbWVudEF1dGhlbnRpY2F0",
+            "aW9uVG9rZW4SUi5pbXByb2JhYmxlLnNwYXRpYWxvcy5wbGF5ZXJhdXRoLnYy",
+            "YWxwaGExLkdldERldmVsb3BtZW50QXV0aGVudGljYXRpb25Ub2tlblJlcXVl",
+            "c3QaUy5pbXByb2JhYmxlLnNwYXRpYWxvcy5wbGF5ZXJhdXRoLnYyYWxwaGEx",
+            "LkdldERldmVsb3BtZW50QXV0aGVudGljYXRpb25Ub2tlblJlc3BvbnNlEtIB",
+            "CiNMaXN0RGV2ZWxvcG1lbnRBdXRoZW50aWNhdGlvblRva2VucxJULmltcHJv",
+            "YmFibGUuc3BhdGlhbG9zLnBsYXllcmF1dGgudjJhbHBoYTEuTGlzdERldmVs",
+            "b3BtZW50QXV0aGVudGljYXRpb25Ub2tlbnNSZXF1ZXN0GlUuaW1wcm9iYWJs",
+            "ZS5zcGF0aWFsb3MucGxheWVyYXV0aC52MmFscGhhMS5MaXN0RGV2ZWxvcG1l",
+            "bnRBdXRoZW50aWNhdGlvblRva2Vuc1Jlc3BvbnNlEtUBCiRVcGRhdGVEZXZl",
+            "bG9wbWVudEF1dGhlbnRpY2F0aW9uVG9rZW4SVS5pbXByb2JhYmxlLnNwYXRp",
+            "YWxvcy5wbGF5ZXJhdXRoLnYyYWxwaGExLlVwZGF0ZURldmVsb3BtZW50QXV0",
+            "aGVudGljYXRpb25Ub2tlblJlcXVlc3QaVi5pbXByb2JhYmxlLnNwYXRpYWxv",
+            "cy5wbGF5ZXJhdXRoLnYyYWxwaGExLlVwZGF0ZURldmVsb3BtZW50QXV0aGVu",
+            "dGljYXRpb25Ub2tlblJlc3BvbnNlEtUBCiRFeHBpcmVEZXZlbG9wbWVudEF1",
+            "dGhlbnRpY2F0aW9uVG9rZW4SVS5pbXByb2JhYmxlLnNwYXRpYWxvcy5wbGF5",
+            "ZXJhdXRoLnYyYWxwaGExLkV4cGlyZURldmVsb3BtZW50QXV0aGVudGljYXRp",
+            "b25Ub2tlblJlcXVlc3QaVi5pbXByb2JhYmxlLnNwYXRpYWxvcy5wbGF5ZXJh",
+            "dXRoLnYyYWxwaGExLkV4cGlyZURldmVsb3BtZW50QXV0aGVudGljYXRpb25U",
+            "b2tlblJlc3BvbnNlQmBaM2ltcHJvYmFibGUvc3BhdGlhbG9zL3BsYXllcmF1",
+            "dGgvdjJhbHBoYTE7cGxheWVyYXV0aKoCKEltcHJvYmFibGUuU3BhdGlhbE9T",
+            "LlBsYXllckF1dGguVjJBbHBoYTFiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.DurationReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::Validator.ValidatorReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
@@ -137,7 +137,7 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.PlayerIdentityToken), global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.PlayerIdentityToken.Parser, new[]{ "Provider", "PlayerIdentifier", "ProjectName", "DisplayName", "Metadata", "IssuedAtTime", "ExpiryTime" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.DevelopmentAuthenticationToken), global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.DevelopmentAuthenticationToken.Parser, new[]{ "Id", "ProjectName", "Description", "CreationTime", "ExpirationTime" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.CreateDevelopmentAuthenticationTokenRequest), global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.CreateDevelopmentAuthenticationTokenRequest.Parser, new[]{ "ProjectName", "Description", "Lifetime" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.CreateDevelopmentAuthenticationTokenResponse), global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.CreateDevelopmentAuthenticationTokenResponse.Parser, new[]{ "DevelopmentAuthenticationToken" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.CreateDevelopmentAuthenticationTokenResponse), global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.CreateDevelopmentAuthenticationTokenResponse.Parser, new[]{ "DevelopmentAuthenticationToken", "TokenSecret" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.GetDevelopmentAuthenticationTokenRequest), global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.GetDevelopmentAuthenticationTokenRequest.Parser, new[]{ "Id" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.GetDevelopmentAuthenticationTokenResponse), global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.GetDevelopmentAuthenticationTokenResponse.Parser, new[]{ "DevelopmentAuthenticationToken" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.ListDevelopmentAuthenticationTokensRequest), global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.ListDevelopmentAuthenticationTokensRequest.Parser, new[]{ "ProjectName", "IncludeExpired", "PageSize", "PageToken" }, null, null, null),
@@ -230,7 +230,7 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
     /// <summary>
     /// Specifies how long the LT is valid for.
     ///
-    /// This field is optional. If unset, it defaults to 15 minutes. The maximum value is 30 minutes.
+    /// This field is optional. If unset or 0, it defaults to 15 minutes. The maximum value is 30 minutes.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Google.Protobuf.WellKnownTypes.Duration LifetimeDuration {
@@ -1248,6 +1248,7 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
     /// The system that was used to authenticate the player with, for example Steam or Google.
     ///
     /// This corresponds to the `prvdr` claim in the JWT.
+    /// This field is exposed to workers through the Player Connection Entity.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Provider {
@@ -1265,6 +1266,7 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
     ///
     /// This should uniquely identify a user in the specified provider.
     /// This corresponds to the `sub` claim in the JWT.
+    /// This field is exposed to workers through the Player Connection Entity.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string PlayerIdentifier {
@@ -1313,6 +1315,7 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
     /// Additional metadata that is stored within the PIT.
     ///
     /// This corresponds to the `md` claim in the JWT.
+    /// This field is exposed to workers through the Player Connection Entity.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public pb::ByteString Metadata {
@@ -2021,6 +2024,7 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public CreateDevelopmentAuthenticationTokenResponse(CreateDevelopmentAuthenticationTokenResponse other) : this() {
       DevelopmentAuthenticationToken = other.developmentAuthenticationToken_ != null ? other.DevelopmentAuthenticationToken.Clone() : null;
+      tokenSecret_ = other.tokenSecret_;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2032,13 +2036,27 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
     public const int DevelopmentAuthenticationTokenFieldNumber = 1;
     private global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.DevelopmentAuthenticationToken developmentAuthenticationToken_;
     /// <summary>
-    /// The newly created DAT.
+    /// The newly created DAT metadata.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.DevelopmentAuthenticationToken DevelopmentAuthenticationToken {
       get { return developmentAuthenticationToken_; }
       set {
         developmentAuthenticationToken_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "token_secret" field.</summary>
+    public const int TokenSecretFieldNumber = 2;
+    private string tokenSecret_ = "";
+    /// <summary>
+    /// The secret value of the DAT. This cannot be retrieved again.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string TokenSecret {
+      get { return tokenSecret_; }
+      set {
+        tokenSecret_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -2056,6 +2074,7 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
         return true;
       }
       if (!object.Equals(DevelopmentAuthenticationToken, other.DevelopmentAuthenticationToken)) return false;
+      if (TokenSecret != other.TokenSecret) return false;
       return true;
     }
 
@@ -2063,6 +2082,7 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
     public override int GetHashCode() {
       int hash = 1;
       if (developmentAuthenticationToken_ != null) hash ^= DevelopmentAuthenticationToken.GetHashCode();
+      if (TokenSecret.Length != 0) hash ^= TokenSecret.GetHashCode();
       return hash;
     }
 
@@ -2077,6 +2097,10 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
         output.WriteRawTag(10);
         output.WriteMessage(DevelopmentAuthenticationToken);
       }
+      if (TokenSecret.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(TokenSecret);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2084,6 +2108,9 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
       int size = 0;
       if (developmentAuthenticationToken_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(DevelopmentAuthenticationToken);
+      }
+      if (TokenSecret.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(TokenSecret);
       }
       return size;
     }
@@ -2098,6 +2125,9 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
           developmentAuthenticationToken_ = new global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.DevelopmentAuthenticationToken();
         }
         DevelopmentAuthenticationToken.MergeFrom(other.DevelopmentAuthenticationToken);
+      }
+      if (other.TokenSecret.Length != 0) {
+        TokenSecret = other.TokenSecret;
       }
     }
 
@@ -2114,6 +2144,10 @@ namespace Improbable.SpatialOS.PlayerAuth.V2Alpha1 {
               developmentAuthenticationToken_ = new global::Improbable.SpatialOS.PlayerAuth.V2Alpha1.DevelopmentAuthenticationToken();
             }
             input.ReadMessage(developmentAuthenticationToken_);
+            break;
+          }
+          case 18: {
+            TokenSecret = input.ReadString();
             break;
           }
         }

--- a/apis/snapshot_v1alpha1/Snapshot.cs
+++ b/apis/snapshot_v1alpha1/Snapshot.cs
@@ -514,7 +514,9 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
     public const int PageSizeFieldNumber = 3;
     private int pageSize_;
     /// <summary>
-    /// The number of snapshots to provide in each page of the paginated results.
+    /// Optional. The number of snapshots to fetch in each page of the paginated results.
+    /// If provided, the `page_size` must be a positive integer. If omitted,
+    /// the default value of 20 is used.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public int PageSize {
@@ -528,8 +530,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
     public const int PageTokenFieldNumber = 4;
     private string pageToken_ = "";
     /// <summary>
-    /// A token, previously provided by the service as a `next_page_token`, for retrieving additional
-    /// pages of paginated results.
+    /// Optional. An opaque token to identify the start of the paginated results.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string PageToken {
@@ -699,6 +700,9 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
     private static readonly pb::FieldCodec<global::Improbable.SpatialOS.Snapshot.V1Alpha1.Snapshot> _repeated_snapshot_codec
         = pb::FieldCodec.ForMessage(10, global::Improbable.SpatialOS.Snapshot.V1Alpha1.Snapshot.Parser);
     private readonly pbc::RepeatedField<global::Improbable.SpatialOS.Snapshot.V1Alpha1.Snapshot> snapshot_ = new pbc::RepeatedField<global::Improbable.SpatialOS.Snapshot.V1Alpha1.Snapshot>();
+    /// <summary>
+    /// By default, snapshots are sorted by creation time (descending).
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public pbc::RepeatedField<global::Improbable.SpatialOS.Snapshot.V1Alpha1.Snapshot> Snapshot {
       get { return snapshot_; }
@@ -872,7 +876,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
     public const int IdFieldNumber = 3;
     private string id_ = "";
     /// <summary>
-    /// The identifier for the desired snapshot.
+    /// The identifier for the snapshot.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public string Id {
@@ -1146,6 +1150,16 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
     /// <summary>Field number for the "snapshot" field.</summary>
     public const int SnapshotFieldNumber = 1;
     private global::Improbable.SpatialOS.Snapshot.V1Alpha1.Snapshot snapshot_;
+    /// <summary>
+    /// These fields are mandatory:
+    /// - `project_name`
+    /// - `deployment_name`
+    ///
+    /// These fields are optional:
+    /// - `tags`
+    ///
+    /// Other set values will be ignored.
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Improbable.SpatialOS.Snapshot.V1Alpha1.Snapshot Snapshot {
       get { return snapshot_; }
@@ -1358,6 +1372,17 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
     /// <summary>Field number for the "snapshot" field.</summary>
     public const int SnapshotFieldNumber = 1;
     private global::Improbable.SpatialOS.Snapshot.V1Alpha1.Snapshot snapshot_;
+    /// <summary>
+    /// These fields are mandatory:
+    /// - `project_name`
+    /// - `deployment_name`
+    /// - `checksum`
+    ///
+    /// These fields are optional:
+    /// - `tags`
+    ///
+    /// Other set values will be ignored.
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public global::Improbable.SpatialOS.Snapshot.V1Alpha1.Snapshot Snapshot {
       get { return snapshot_; }

--- a/apis/snapshot_v1alpha1/SnapshotGrpc.cs
+++ b/apis/snapshot_v1alpha1/SnapshotGrpc.cs
@@ -75,23 +75,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
     public abstract partial class SnapshotServiceBase
     {
       /// <summary>
-      /// List a deployment's snapshots.
-      ///
-      /// The following fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// The remaining fields are optional:
-      ///  - If provided, the `page_size` must be a positive integer. If omitted,
-      ///    the default value of 20 is used.
-      ///  - The `page_token` should be omitted in the first request. If the response
-      ///    contains a page token, this token should be included in the next request, and
-      ///    so on until a response is received with no page token.
-      ///
-      /// Snapshots are sorted by creation time, descending.
+      /// Lists snapshots under a deployment.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -102,18 +86,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
       }
 
       /// <summary>
-      /// Get the details of a specific snapshot.
-      ///
-      /// These fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `id`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `id` must be a 64-bit integer.
-      ///
-      /// Empty or invalid fields result in an `InvalidArgument` error.
+      /// Gets a snapshot.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -124,25 +97,9 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
       }
 
       /// <summary>
-      /// Take a snapshot of a running deployment.
+      /// Takes a snapshot of a running deployment.
       ///
-      /// Currently, you can only supply these fields:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `tags`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// In addition, these fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set either of these will result in an `InvalidArgument` error.
-      ///
-      /// The returned operation result is of type `snapshot`.
+      /// The returned operation result is of type `snapshot` upon successfully taking a snapshot.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -153,25 +110,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
       }
 
       /// <summary>
-      /// Upload a new snapshot (returns a URL to upload its contents to).
-      ///
-      /// Currently, you can only supply these fields:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `tags`
-      /// - `checksum`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// In addition, these fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `checksum`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set any of these will result in an `InvalidArgument` error.
+      /// Allocates space and returns a URL to upload a snapshot to.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -182,19 +121,8 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
       }
 
       /// <summary>
-      /// Confirm the Snapshot has been POSTed to the URL obtain from UploadSnapshot.
-      ///
-      /// These fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `id`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set any of these will result in an `InvalidArgument` error.
+      /// Confirms that a snapshot is uploaded to the URL allocated by the `UploadSnapshot` RPC and makes it available
+      /// for use in a deployment.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
       /// <param name="context">The context of the server-side call handler being invoked.</param>
@@ -230,23 +158,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
       }
 
       /// <summary>
-      /// List a deployment's snapshots.
-      ///
-      /// The following fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// The remaining fields are optional:
-      ///  - If provided, the `page_size` must be a positive integer. If omitted,
-      ///    the default value of 20 is used.
-      ///  - The `page_token` should be omitted in the first request. If the response
-      ///    contains a page token, this token should be included in the next request, and
-      ///    so on until a response is received with no page token.
-      ///
-      /// Snapshots are sorted by creation time, descending.
+      /// Lists snapshots under a deployment.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -258,23 +170,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return ListSnapshots(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// List a deployment's snapshots.
-      ///
-      /// The following fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// The remaining fields are optional:
-      ///  - If provided, the `page_size` must be a positive integer. If omitted,
-      ///    the default value of 20 is used.
-      ///  - The `page_token` should be omitted in the first request. If the response
-      ///    contains a page token, this token should be included in the next request, and
-      ///    so on until a response is received with no page token.
-      ///
-      /// Snapshots are sorted by creation time, descending.
+      /// Lists snapshots under a deployment.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -284,23 +180,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return CallInvoker.BlockingUnaryCall(__Method_ListSnapshots, null, options, request);
       }
       /// <summary>
-      /// List a deployment's snapshots.
-      ///
-      /// The following fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// The remaining fields are optional:
-      ///  - If provided, the `page_size` must be a positive integer. If omitted,
-      ///    the default value of 20 is used.
-      ///  - The `page_token` should be omitted in the first request. If the response
-      ///    contains a page token, this token should be included in the next request, and
-      ///    so on until a response is received with no page token.
-      ///
-      /// Snapshots are sorted by creation time, descending.
+      /// Lists snapshots under a deployment.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -312,23 +192,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return ListSnapshotsAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// List a deployment's snapshots.
-      ///
-      /// The following fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// The remaining fields are optional:
-      ///  - If provided, the `page_size` must be a positive integer. If omitted,
-      ///    the default value of 20 is used.
-      ///  - The `page_token` should be omitted in the first request. If the response
-      ///    contains a page token, this token should be included in the next request, and
-      ///    so on until a response is received with no page token.
-      ///
-      /// Snapshots are sorted by creation time, descending.
+      /// Lists snapshots under a deployment.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -338,18 +202,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return CallInvoker.AsyncUnaryCall(__Method_ListSnapshots, null, options, request);
       }
       /// <summary>
-      /// Get the details of a specific snapshot.
-      ///
-      /// These fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `id`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `id` must be a 64-bit integer.
-      ///
-      /// Empty or invalid fields result in an `InvalidArgument` error.
+      /// Gets a snapshot.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -361,18 +214,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return GetSnapshot(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Get the details of a specific snapshot.
-      ///
-      /// These fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `id`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `id` must be a 64-bit integer.
-      ///
-      /// Empty or invalid fields result in an `InvalidArgument` error.
+      /// Gets a snapshot.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -382,18 +224,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return CallInvoker.BlockingUnaryCall(__Method_GetSnapshot, null, options, request);
       }
       /// <summary>
-      /// Get the details of a specific snapshot.
-      ///
-      /// These fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `id`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `id` must be a 64-bit integer.
-      ///
-      /// Empty or invalid fields result in an `InvalidArgument` error.
+      /// Gets a snapshot.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -405,18 +236,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return GetSnapshotAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Get the details of a specific snapshot.
-      ///
-      /// These fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `id`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `id` must be a 64-bit integer.
-      ///
-      /// Empty or invalid fields result in an `InvalidArgument` error.
+      /// Gets a snapshot.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -426,25 +246,9 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return CallInvoker.AsyncUnaryCall(__Method_GetSnapshot, null, options, request);
       }
       /// <summary>
-      /// Take a snapshot of a running deployment.
+      /// Takes a snapshot of a running deployment.
       ///
-      /// Currently, you can only supply these fields:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `tags`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// In addition, these fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set either of these will result in an `InvalidArgument` error.
-      ///
-      /// The returned operation result is of type `snapshot`.
+      /// The returned operation result is of type `snapshot` upon successfully taking a snapshot.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -456,25 +260,9 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return TakeSnapshot(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Take a snapshot of a running deployment.
+      /// Takes a snapshot of a running deployment.
       ///
-      /// Currently, you can only supply these fields:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `tags`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// In addition, these fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set either of these will result in an `InvalidArgument` error.
-      ///
-      /// The returned operation result is of type `snapshot`.
+      /// The returned operation result is of type `snapshot` upon successfully taking a snapshot.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -484,25 +272,9 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return CallInvoker.BlockingUnaryCall(__Method_TakeSnapshot, null, options, request);
       }
       /// <summary>
-      /// Take a snapshot of a running deployment.
+      /// Takes a snapshot of a running deployment.
       ///
-      /// Currently, you can only supply these fields:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `tags`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// In addition, these fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set either of these will result in an `InvalidArgument` error.
-      ///
-      /// The returned operation result is of type `snapshot`.
+      /// The returned operation result is of type `snapshot` upon successfully taking a snapshot.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -514,25 +286,9 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return TakeSnapshotAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Take a snapshot of a running deployment.
+      /// Takes a snapshot of a running deployment.
       ///
-      /// Currently, you can only supply these fields:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `tags`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// In addition, these fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set either of these will result in an `InvalidArgument` error.
-      ///
-      /// The returned operation result is of type `snapshot`.
+      /// The returned operation result is of type `snapshot` upon successfully taking a snapshot.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -542,25 +298,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return CallInvoker.AsyncUnaryCall(__Method_TakeSnapshot, null, options, request);
       }
       /// <summary>
-      /// Upload a new snapshot (returns a URL to upload its contents to).
-      ///
-      /// Currently, you can only supply these fields:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `tags`
-      /// - `checksum`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// In addition, these fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `checksum`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set any of these will result in an `InvalidArgument` error.
+      /// Allocates space and returns a URL to upload a snapshot to.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -572,25 +310,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return UploadSnapshot(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Upload a new snapshot (returns a URL to upload its contents to).
-      ///
-      /// Currently, you can only supply these fields:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `tags`
-      /// - `checksum`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// In addition, these fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `checksum`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set any of these will result in an `InvalidArgument` error.
+      /// Allocates space and returns a URL to upload a snapshot to.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -600,25 +320,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return CallInvoker.BlockingUnaryCall(__Method_UploadSnapshot, null, options, request);
       }
       /// <summary>
-      /// Upload a new snapshot (returns a URL to upload its contents to).
-      ///
-      /// Currently, you can only supply these fields:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `tags`
-      /// - `checksum`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// In addition, these fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `checksum`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set any of these will result in an `InvalidArgument` error.
+      /// Allocates space and returns a URL to upload a snapshot to.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -630,25 +332,7 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return UploadSnapshotAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Upload a new snapshot (returns a URL to upload its contents to).
-      ///
-      /// Currently, you can only supply these fields:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `tags`
-      /// - `checksum`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// In addition, these fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `checksum`
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set any of these will result in an `InvalidArgument` error.
+      /// Allocates space and returns a URL to upload a snapshot to.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -658,19 +342,8 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return CallInvoker.AsyncUnaryCall(__Method_UploadSnapshot, null, options, request);
       }
       /// <summary>
-      /// Confirm the Snapshot has been POSTed to the URL obtain from UploadSnapshot.
-      ///
-      /// These fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `id`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set any of these will result in an `InvalidArgument` error.
+      /// Confirms that a snapshot is uploaded to the URL allocated by the `UploadSnapshot` RPC and makes it available
+      /// for use in a deployment.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -682,19 +355,8 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return ConfirmUpload(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Confirm the Snapshot has been POSTed to the URL obtain from UploadSnapshot.
-      ///
-      /// These fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `id`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set any of these will result in an `InvalidArgument` error.
+      /// Confirms that a snapshot is uploaded to the URL allocated by the `UploadSnapshot` RPC and makes it available
+      /// for use in a deployment.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>
@@ -704,19 +366,8 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return CallInvoker.BlockingUnaryCall(__Method_ConfirmUpload, null, options, request);
       }
       /// <summary>
-      /// Confirm the Snapshot has been POSTed to the URL obtain from UploadSnapshot.
-      ///
-      /// These fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `id`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set any of these will result in an `InvalidArgument` error.
+      /// Confirms that a snapshot is uploaded to the URL allocated by the `UploadSnapshot` RPC and makes it available
+      /// for use in a deployment.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
@@ -728,19 +379,8 @@ namespace Improbable.SpatialOS.Snapshot.V1Alpha1 {
         return ConfirmUploadAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// Confirm the Snapshot has been POSTed to the URL obtain from UploadSnapshot.
-      ///
-      /// These fields are mandatory:
-      /// - `project_name`
-      /// - `deployment_name`
-      /// - `id`
-      ///
-      /// Other set values will be ignored.
-      ///
-      /// `project_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      /// `deployment_name` must conform to the regex: ^[a-z0-9_]{3,32}$
-      ///
-      /// Failure to set any of these will result in an `InvalidArgument` error.
+      /// Confirms that a snapshot is uploaded to the URL allocated by the `UploadSnapshot` RPC and makes it available
+      /// for use in a deployment.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
       /// <param name="options">The options for the call.</param>


### PR DESCRIPTION
Updating with the description and runtime_version fields that were added to the deployment proto. The runtime_version in particular is needed for feature parity with cloud Mercury. 

(Also pulled in a bunch of documentation changes that were made)