### PR TITLE
Consolidate scripts

### DIFF
--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -16,7 +16,7 @@ common: &common
     - "environment=production"
     - "permission_set=builder"
     - "platform=linux"
-    - "queue=${CI_BUILDER_QUEUE:-v2-1553093147-c5086c3db10e3761-------z}"
+    - "queue=${CI_BUILDER_QUEUE:-v3-1558960120-4a170e85e982b36f-------z}"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:
     automatic:

--- a/.buildkite/premerge.definition.yaml
+++ b/.buildkite/premerge.definition.yaml
@@ -1,5 +1,5 @@
 agent_queue_id: trigger-pipelines
-description: Add a description...
+description: The premerge steps to run for Platform SDK pull-requests.
 github:
   branch_configuration: []
   default_branch: master

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -16,7 +16,7 @@ common: &common
     - "environment=production"
     - "permission_set=builder"
     - "platform=linux"
-    - "queue=${CI_BUILDER_QUEUE:-v2-1553093147-c5086c3db10e3761-------z}"
+    - "queue=${CI_BUILDER_QUEUE:-v3-1558960120-4a170e85e982b36f-------z}"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:
     automatic:

--- a/scripts/generateapis.sh
+++ b/scripts/generateapis.sh
@@ -1,22 +1,25 @@
 #!/usr/bin/env bash
 
-set -e
+set -e -u -x -o pipefail
 
-REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+source scripts/includes/bazel.sh
 
 generate_api() {
-    NAME=$1
-    VERSION=$2
-    PACKAGE=apis/${NAME}_${VERSION}
+    NAME="$1"
+    VERSION="$2"
+    PACKAGE="apis/${NAME}_${VERSION}"
 
-    bazel build //$PACKAGE:gapic
-    bazel build //$PACKAGE:grpc
-    rm -rf $PACKAGE/*.cs
-    cp -R $REPO_ROOT/bazel-genfiles/$PACKAGE/${NAME}_gapicout/*/*/*.cs $REPO_ROOT/$PACKAGE
-    cp -R $REPO_ROOT/bazel-genfiles/$PACKAGE/*.cs $REPO_ROOT/$PACKAGE
+    runBazel build "//${PACKAGE}:gapic"
+    runBazel build "//${PACKAGE}:grpc"
+    rm -rf ${PACKAGE}/*.cs
+    copyBazelOutput "bazel-genfiles/${PACKAGE}/${NAME}_gapicout/*/*/*.cs" "${REPO_ROOT}/${PACKAGE}"
+    copyBazelOutput "bazel-genfiles/${PACKAGE}/*.cs" "${REPO_ROOT}/${PACKAGE}"
 }
 
-generate_api 'deployment' 'v1alpha1'
-generate_api 'snapshot' 'v1alpha1'
-generate_api 'serviceaccount' 'v1alpha1'
-generate_api 'playerauth' 'v2alpha1'
+generate_api "deployment" "v1alpha1"
+generate_api "snapshot" "v1alpha1"
+generate_api "serviceaccount" "v1alpha1"
+generate_api "playerauth" "v2alpha1"

--- a/scripts/includes/bazel.sh
+++ b/scripts/includes/bazel.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+source scripts/includes/os.sh
+
+if isLinux; then
+  DEFAULT_BAZEL_CONFIG="k8-gcc-opt"
+elif isMacOS; then
+  DEFAULT_BAZEL_CONFIG="darwin-opt-clang"
+else
+  DEFAULT_BAZEL_CONFIG="x64_windows-opt-msvc_md"
+fi
+
+# By convention bazel config's names are identical to their output folder names.
+DEFAULT_BAZEL_OUT="bazel-out/${DEFAULT_BAZEL_CONFIG}"
+DEFAULT_BAZEL_BIN="${DEFAULT_BAZEL_OUT}/bin"
+
+# Main function that should be used by scripts sourcing this file.
+function runBazel() {
+  "$(pwd)/tools/bazel" "$@"
+}
+
+function copyBazelOutput() {
+  cp -Rf "$1" "$2"
+  chmod +w "$2"
+}

--- a/scripts/includes/os.sh
+++ b/scripts/includes/os.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+function isLinux() {
+  [[ "$(uname -s)" == "Linux" ]];
+}
+
+function isMacOS() {
+  [[ "$(uname -s)" == "Darwin" ]];
+}
+
+function isWindows() {
+  ! ( isLinux || isMacOS );
+}
+
+# Return the target platform used by worker package names built for this OS.
+function getPlatformName() {
+  if isLinux; then
+    echo "linux"
+  elif isMacOS; then
+    echo "macos"
+  elif isWindows; then
+    echo "win32"
+  else
+    echo "ERROR: Unknown platform." >&2
+    exit 1
+  fi
+}

--- a/scripts/nightly.sh
+++ b/scripts/nightly.sh
@@ -1,24 +1,37 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -e -u -o pipefail
 
-REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-SDK_VERSION_NIGHTLY=999.9.9-NIGHTLY
-DOCKER_IMAGE=platform-sdk/csharp:$SDK_VERSION_NIGHTLY
+REPO_ROOT="$(dirname "$0")/.."
+cd "${REPO_ROOT}"
 
-if [[ -z ${IMPROBABLE_REFRESH_TOKEN+x} ]]; 
-then 
+SDK_VERSION_NIGHTLY="999.9.9-NIGHTLY"
+DOCKER_IMAGE="platform-sdk/csharp:${SDK_VERSION_NIGHTLY}"
+
+if [[ -z "${IMPROBABLE_REFRESH_TOKEN+x}" ]]; 
+then
     echo "IMPROBABLE_REFRESH_TOKEN is unset."
     echo "Trying to retrieve from vaults."
-    IMPROBABLE_REFRESH_TOKEN="$(imp-ci secrets read --environment=production --buildkite-org=improbable --secret-type=spatialos-service-account --secret-name=platform-sdk --field=token)"
+    IMPROBABLE_REFRESH_TOKEN="$(imp-ci secrets read \
+      --environment=production \
+      --buildkite-org=improbable \
+      --secret-type=spatialos-sevice-account \
+      --secret-name=platform-sdk \
+      --field=token
+    )"
 fi
 
-echo "--- regenerating APIs"
-echo "skipping until bazel is available on the agent"
-# $REPO_ROOT/scripts/generateapis.sh
+echo "--- Regenerating APIs"
+echo "Skipping until bazel is available on the agent"
+# scripts/generateapis.sh
 
 echo "--- Preparing docker image for nightly"
-docker build --build-arg IMPROBABLE_REFRESH_TOKEN=$IMPROBABLE_REFRESH_TOKEN --build-arg SDK_VERSION=$SDK_VERSION_NIGHTLY -t $DOCKER_IMAGE $REPO_ROOT
+docker build \
+  --build-arg "IMPROBABLE_REFRESH_TOKEN=${IMPROBABLE_REFRESH_TOKEN}" \
+  --build-arg "SDK_VERSION=${SDK_VERSION_NIGHTLY}" \
+  --tag "${DOCKER_IMAGE}" \
+  "${REPO_ROOT}"
 
 echo "--- Running scenarios in docker"
-$REPO_ROOT/scripts/runtests.sh $DOCKER_IMAGE
+scripts/runtests.sh "${DOCKER_IMAGE}"
+

--- a/scripts/premerge.sh
+++ b/scripts/premerge.sh
@@ -1,24 +1,37 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -e -u -o pipefail
 
-if [[ -z ${IMPROBABLE_REFRESH_TOKEN+x} ]]; 
+REPO_ROOT="$(dirname "$0")/.."
+cd "${REPO_ROOT}"
+
+SDK_VERSION_PREMERGE="888.8.8-PREMERGE"
+DOCKER_IMAGE="platform-sdk/csharp:${SDK_VERSION_PREMERGE}"
+
+if [[ -z "${IMPROBABLE_REFRESH_TOKEN+x}" ]]; 
 then 
     echo "IMPROBABLE_REFRESH_TOKEN is unset."
     echo "Trying to retrieve from vaults."
-    IMPROBABLE_REFRESH_TOKEN="$(imp-ci secrets read --environment=production --buildkite-org=improbable --secret-type=spatialos-service-account --secret-name=platform-sdk --field=token)"
+    IMPROBABLE_REFRESH_TOKEN="$(imp-ci secrets read \
+      --environment=production \
+      --buildkite-org=improbable \
+      --secret-type=spatialos-service-account \
+      --secret-name=platform-sdk \
+      --field=token
+    )"
 fi
 
-REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-SDK_VERSION_PREMERGE=888.8.8-PREMERGE
-DOCKER_IMAGE=platform-sdk/csharp:$SDK_VERSION_PREMERGE
-
-echo "--- regenerating APIs"
-echo "skipping until bazel is available on the agent"
-# $REPO_ROOT/scripts/generateapis.sh
+echo "--- Regenerating APIs"
+echo "Skipping until bazel is available on the agent"
+# scripts/generateapis.sh
 
 echo "--- Preparing docker image for premerge"
-docker build --build-arg IMPROBABLE_REFRESH_TOKEN=$IMPROBABLE_REFRESH_TOKEN --build-arg SDK_VERSION=$SDK_VERSION_PREMERGE -t $DOCKER_IMAGE $REPO_ROOT
+docker build \
+  --build-arg "IMPROBABLE_REFRESH_TOKEN=${IMPROBABLE_REFRESH_TOKEN}" \
+  --build-arg "SDK_VERSION=${SDK_VERSION_PREMERGE}" \
+  --tag "${DOCKER_IMAGE}" \
+  "${REPO_ROOT}"
 
 echo "--- Running scenarios in docker"
-$REPO_ROOT/scripts/runtests.sh $DOCKER_IMAGE
+scripts/runtests.sh "${DOCKER_IMAGE}"
+

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,37 +1,46 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -e -u -o pipefail
 
-if [[ -z ${SDK_VERSION+x} ]]; then
-  echo "Pls provide SDK_VERSION."
+REPO_ROOT="$(dirname "$0")/.."
+cd "${REPO_ROOT}"
+
+DOCKER_IMAGE="platform-sdk/csharp"
+ARTEFACT_DIR="${REPO_ROOT}/artefacts"
+OUTPUT_DIR="${REPO_ROOT}/apis/bin/Release"
+
+if [[ -z "${SDK_VERSION+x}" ]]; then
+  echo "Please set the SDK_VERSION environment variable to the correct version."
   exit 1
 fi
 
-if [[ -z ${NUGET_API_KEY+x} ]]; then
-  echo "NUGET_API_KEY is unset."
+if [[ -z "${NUGET_API_KEY+x}" ]]; then
+  echo "Please set the NUGET_API_KEY environment variable."
   # echo "Trying to retrieve from vaults."
   # IMPROBABLE_REFRESH_TOKEN="$(imp-ci secrets read --environment=production --buildkite-org=improbable --secret-type=spatialos-service-account --secret-name=platform-sdk)"
 fi
 
-REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-DOCKER_IMAGE=platform-sdk/csharp
-ARTEFACT_DIR=$REPO_ROOT/artefacts
-OUTPUT_DIR=$REPO_ROOT/apis/bin/Release
-
 echo "--- Clearing artefacts from previous runs"
-mkdir -p $ARTEFACT_DIR
-rm -rf $ARTEFACT_DIR/*
+rm -rf "${ARTEFACT_DIR}"
+mkdir -p "${ARTEFACT_DIR}"
 
 echo "--- Preparing artefacts for release"
-msbuild $REPO_ROOT/apis/apis.csproj /p:Configuration=Release /p:Version=${SDK_VERSION} /t:Clean,Build -verbosity:minimal
-pushd ${OUTPUT_DIR}/net451
-zip -r ${ARTEFACT_DIR}/${SDK_VERSION}-net451.zip *
+msbuild "${REPO_ROOT}/apis/apis.csproj" \
+  /p:Configuration=Release \
+  /p:Version="${SDK_VERSION}" \
+  /t:Clean,Build \
+  -verbosity:minimal
+
+pushd "${OUTPUT_DIR}/net451"
+  zip -r "${ARTEFACT_DIR}/${SDK_VERSION}-net451.zip" *
 popd
-cp ${OUTPUT_DIR}/Improbable.SpatialOS.Platform.${SDK_VERSION}.nupkg ${ARTEFACT_DIR}
+
+cp "${OUTPUT_DIR}/Improbable.SpatialOS.Platform.${SDK_VERSION}.nupkg" "${ARTEFACT_DIR}"
 
 echo "--- Publishing to NuGet"
-nuget setApiKey ${NUGET_API_KEY}
-nuget push ${ARTEFACT_DIR}/Improbable.SpatialOS.Platform.${SDK_VERSION}.nupkg -Source https://api.nuget.org/v3/index.json
+nuget setApiKey "${NUGET_API_KEY}"
+nuget push "${ARTEFACT_DIR}/Improbable.SpatialOS.Platform.${SDK_VERSION}.nupkg" -Source https://api.nuget.org/v3/index.json
 
 echo "--- Publishing to SpatialOS Package service"
-package_client publish platform_sdk csharp $SDK_VERSION ${ARTEFACT_DIR}/${SDK_VERSION}-net451.zip
+package_client publish platform_sdk csharp "${SDK_VERSION}" "${ARTEFACT_DIR}/${SDK_VERSION}-net451.zip"
+

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
 
-set -e
+set -e -u -o pipefail
 
-if [[ $# -ne 1 ]]; then
+if [[ "$#" -ne 1 ]]; then
   echo "Supply the docker image name as the first argument."
   exit 1
 fi
 
-DOCKER_IMAGE=$1
+DOCKER_IMAGE="$1"
 
 echo "--- Running Game Maintenance Scenario"
-docker run $DOCKER_IMAGE /bin/bash -c "cd examples/GameMaintenance && dotnet run --no-build --configuration Release"
+docker run \
+  --workdir="/workspace/examples/GameMaintenance" \
+  "${DOCKER_IMAGE}" \
+  /bin/bash -c "dotnet run --no-build --configuration Release"
 
 echo "--- Running Service Account Maintenance Scenario"
-docker run $DOCKER_IMAGE /bin/bash -c "cd examples/ServiceAccountMaintenance && dotnet run --no-build --configuration Release"
+docker run \
+  --workdir="/workspace/examples/ServiceAccountMaintenance" \
+  "${DOCKER_IMAGE}" \
+  /bin/bash -c "dotnet run --no-build --configuration Release"
 
 echo "--- Running Replicate State Scenario"
-docker run $DOCKER_IMAGE /bin/bash -c "cd examples && spatial service start --main_config=blank_project/spatialos.json && cd ReplicateState && dotnet run --no-build --configuration Release"
+docker run \
+  --workdir="/workspace/examples" \
+  "${DOCKER_IMAGE}" \
+  /bin/bash -c "spatial service start --main_config=blank_project/spatialos.json && cd ReplicateState && dotnet run --no-build --configuration Release"
 
 echo "--- Running BYO Auth Scenario"
-docker run $DOCKER_IMAGE /bin/bash -c "cd examples && cd BYOAuthFlow && dotnet run --no-build --configuration Release"
+docker run \
+  --workdir="/workspace/examples/BYOAuthFlow" \
+  "${DOCKER_IMAGE}" \
+  /bin/bash -c "dotnet run --no-build --configuration Release"
 
 echo "--- Running Capacity Limit Scenario"
-docker run $DOCKER_IMAGE /bin/bash -c "cd examples/CapacityLimit && dotnet run --no-build --configuration Release"
+docker run \
+  --workdir="/workspace/examples/CapacityLimit" \
+  "${DOCKER_IMAGE}" \
+  /bin/bash -c "dotnet run --no-build --configuration Release"
+

--- a/tools/bazel
+++ b/tools/bazel
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+TOOLS_DIR="$(dirname "$0")"
+
+source "${TOOLS_DIR}"/../scripts/includes/os.sh
+
+# All information required for the script to select or, if necessary, install bazel is contained
+# in this code block.
+# If a higher version of bazel is required, update `REQUIRED_BAZEL_VERSION` and the
+# `REQUIRED_BAZEL_SHA256` values for each platform.
+REQUIRED_BAZEL_VERSION="0.18.1"
+BAZEL_INSTALLATION_DIR="${HOME}/.bazel_installations/${REQUIRED_BAZEL_VERSION}"
+if isLinux; then
+  REQUIRED_BAZEL_SHA256="68d4bdd3d467030561f0859765252286aae62146e8262d3981335a272b461498"
+  REQUIRED_BAZEL_SHA256CMD="sha256sum"
+  DOWNLOAD_CMD="wget -q --no-clobber -O bazel"
+  BAZEL_EXE="bazel-${REQUIRED_BAZEL_VERSION}-linux-x86_64"
+elif isMacOS; then
+  REQUIRED_BAZEL_SHA256="7502a37f24f41498e0d09b95ec43be1a5a2aadc4398c5313432da8ced8584ee2"
+  REQUIRED_BAZEL_SHA256CMD="shasum -a 256"
+  DOWNLOAD_CMD="wget -q --no-clobber -O bazel"
+  BAZEL_EXE="bazel-${REQUIRED_BAZEL_VERSION}-darwin-x86_64"
+else
+  REQUIRED_BAZEL_SHA256="5c491b74d3d11bedf6e4c62b111cd69a0d97cd1fbe2446a07aa5bb17d14dc7f0"
+  REQUIRED_BAZEL_SHA256CMD="sha256sum"
+  DOWNLOAD_CMD="curl -L -s -o bazel"
+  # Windows does not have an installer but retrieves the executable directly.
+  BAZEL_EXE="bazel-${REQUIRED_BAZEL_VERSION}-windows-x86_64.exe"
+fi
+
+BAZEL_TARGET_PATH="${BAZEL_INSTALLATION_DIR}/bin/bazel"
+
+# Check if correct version is already installed.
+if [ -f "${BAZEL_TARGET_PATH}" ]; then
+  exec -a "$0" "${BAZEL_TARGET_PATH}" "$@"
+fi
+
+cat << EOM
+=================================================
+Bazel version ${REQUIRED_BAZEL_VERSION} is not
+installed under ~/.bazel_installations
+
+Installing bazel ${REQUIRED_BAZEL_VERSION} now...
+=================================================
+EOM
+
+# Create root directory if needed.
+if [ ! -d "${BAZEL_INSTALLATION_DIR}" ]; then
+  echo "Installation directory created."
+  mkdir -p "${BAZEL_INSTALLATION_DIR}"
+fi
+
+function _are_checksums_equal() {
+  CHECKSUM_A=$1
+  CHECKSUM_B=$2
+  # Split apart the checksum from the file name by splitting the returned string by the contained
+  # space; the checksum has the format:
+  # xxxxxx...xxxxx <filename>
+  CHECKSUM_A_PARTS=(${CHECKSUM_A})
+  CHECKSUM_B_PARTS=(${CHECKSUM_B})
+
+  if [[ "${CHECKSUM_A_PARTS[0]}" == "${CHECKSUM_B_PARTS[0]}" ]]; then
+    return 0 # True
+  else
+    return 1 # False
+  fi
+}
+
+# Install correct bazel version.
+# If we don't have a local Bazel install at this point we need to retrieve the right version from GitHub.
+mkdir -p "${BAZEL_INSTALLATION_DIR}/bin/tmp"
+pushd "${BAZEL_INSTALLATION_DIR}/bin/tmp"
+rm bazel 2>/dev/null || true # Remove bazel binary if already present in tmp dir - indicates previous failed download.
+echo "Starting download of bazel ${REQUIRED_BAZEL_VERSION}..."
+${DOWNLOAD_CMD} "https://github.com/bazelbuild/bazel/releases/download/${REQUIRED_BAZEL_VERSION}/${BAZEL_EXE}"
+echo "Download finished."
+echo "Testing download file integrity..."
+CALCULATED_CHECKSUM="$(${REQUIRED_BAZEL_SHA256CMD} bazel)"
+if ! _are_checksums_equal "${CALCULATED_CHECKSUM}" "${REQUIRED_BAZEL_SHA256}"; then
+  cat <<EOM
+  ABORT - Downloaded Bazel failed the SHA-256 hash check.
+  ABORT - Expected: ${REQUIRED_BAZEL_SHA256}  bazel
+  ABORT - Found:    ${CALCULATED_CHECKSUM}
+EOM
+  exit 1
+fi
+# Mark downloaded file executable and move out of tmp directory.
+chmod a+x "bazel"
+mv bazel ..
+popd
+
+echo "Executing downloaded bazel..."
+exec -a "$0" "${BAZEL_TARGET_PATH}" "$@"


### PR DESCRIPTION
Introducing the appropriate CI helper scripts to ensure that when regenerating the API packages we are always using an appropriate version of Bazel, regardless of what you have installed locally. These helper scripts are identical to what we use elsewhere in other code-bases.

Also doing a general pass on the other scripts to align their Bash style with best-practices.