### PR TITLE
Fix REPO_ROOT variable

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,7 +2,7 @@
 
 set -e -u -o pipefail
 
-REPO_ROOT="$(dirname "$0")/.."
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "${REPO_ROOT}"
 
 DOCKER_IMAGE="platform-sdk/csharp"


### PR DESCRIPTION
The changes made to this variable in https://github.com/spatialos/platform-sdk-csharp/pull/31 broke the script. I manually changed it back to this for releasing `13.8.0`. If there's a more idiomatic bash way of doing this please suggest :) 