### PR TITLE
Move to .NET Standard 1.6 and dotnet CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
+# Build artefacts
+artefacts/
 bazel-*
+**/bin/
 **/obj/
 
+# IDE files
 *~
 .idea/
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,23 @@
-FROM microsoft/dotnet:2.0-sdk
+# Adapted from: https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/bionic/amd64/Dockerfile
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-bionic
 
-ENV MONO_VERSION 5.16.0.179
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-RUN echo "deb http://download.mono-project.com/repo/debian stretch/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official.list \
-    && apt-get update \
-    && apt-get install -y mono-runtime \
-    && rm -rf /var/lib/apt/lists/* /tmp/*
-RUN apt-get update \
-    && apt-get install -y binutils curl mono-devel ca-certificates-mono fsharp mono-vbnc nuget referenceassemblies-pcl \
-    && rm -rf /var/lib/apt/lists/* /tmp/*
-
-# Install OpenJDK-8
-RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get clean;
-
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
-RUN export JAVA_HOME
-
+## Improbable specific section
+# Fetch and set up the 'spatial' CLI.
 RUN curl -L https://console.improbable.io/toolbelt/download/latest/linux -o /usr/bin/spatial
 RUN chmod +x /usr/bin/spatial
 RUN spatial update
 
+# Make the sources available in the container.
 WORKDIR /workspace
 COPY apis apis
 COPY examples examples
 COPY scripts scripts
 
-RUN nuget restore examples/examples.sln
-
+# Build the examples for use by scripts.
 ARG SDK_VERSION
-RUN msbuild examples/examples.sln /p:Configuration=Release /p:Version=$SDK_VERSION /t:Clean,Build -verbosity:minimal
+RUN dotnet build examples/examples.sln --configuration Release -p:Version=$SDK_VERSION
 
+# Ensure authentication is available for the 'spatial' CLI and the Platform SDK.
 ARG IMPROBABLE_REFRESH_TOKEN
 ENV IMPROBABLE_REFRESH_TOKEN=$IMPROBABLE_REFRESH_TOKEN
 RUN mkdir -p $HOME/.improbable/oauth2 && echo $IMPROBABLE_REFRESH_TOKEN >> $HOME/.improbable/oauth2/oauth2_refresh_token

--- a/apis/apis.csproj
+++ b/apis/apis.csproj
@@ -1,55 +1,65 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <AssemblyName>Improbable.SpatialOS.Platform</AssemblyName>
-        <RootNamespace>Improbable.SpatialOS.Platform</RootNamespace>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <Deterministic>true</Deterministic>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <Authors>Improbable</Authors>
+        <Copyright>Copyright 2019 Improbable</Copyright>
         <Description>Platform C# SDK that allows interacting with the SpatialOS Platform.</Description>
         <PackageTags>Platform SDK;Improbable;SpatialOS Platform</PackageTags>
-        <Copyright>Copyright 2018 Improbable</Copyright>
-        <Authors>Improbable</Authors>
-        <TargetFrameworks>net451;netstandard1.5</TargetFrameworks>
+        <PackageProjectUrl>https://github.com/spatialos/platform-sdk-csharp</PackageProjectUrl>
+        <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <AssemblyName>Improbable.SpatialOS.Platform</AssemblyName>
+        <RootNamespace>Improbable.SpatialOS.Platform</RootNamespace>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+        <Deterministic>true</Deterministic>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <TargetFrameworks>netstandard1.6</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Google.LongRunning" Version="1.0.0" />
       <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
+      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0-preview.2" />
     </ItemGroup>
 
+    <!-- For details on configuring ILRepack see https://www.phillipsj.net/posts/using-ilrepack-with-dotnet-core-sdk-and-dotnet-standard -->
     <Target Name="ILRepack" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release' ">
         <PropertyGroup>
-            <WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\net451</WorkingDirectory>
+            <WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\netstandard1.6</WorkingDirectory>
         </PropertyGroup>
 
         <ItemGroup>
-            <InputAssemblies Include="Google.Protobuf.dll" />
-            <InputAssemblies Include="System.Interactive.Async.dll" />
-            <InputAssemblies Include="Newtonsoft.Json.dll" />
-            <InputAssemblies Include="Grpc.Core.dll" />
-            <InputAssemblies Include="Grpc.Auth.dll" />
-            <InputAssemblies Include="Google.Protobuf.dll" />
-            <InputAssemblies Include="Google.LongRunning.dll" />
-            <InputAssemblies Include="Google.Apis.PlatformServices.dll" />
-            <InputAssemblies Include="Google.Apis.dll" />
-            <InputAssemblies Include="Google.Apis.Core.dll" />
-            <InputAssemblies Include="Google.Apis.Auth.PlatformServices.dll" />
-            <InputAssemblies Include="Google.Apis.Auth.dll" />
+			<InputAssemblies Include="Improbable.SpatialOS.Platform.dll" />
+            <InputAssemblies Include="Google.Api.CommonProtos.dll" />
             <InputAssemblies Include="Google.Api.Gax.Grpc.dll" />
             <InputAssemblies Include="Google.Api.Gax.dll" />
-            <InputAssemblies Include="Google.Api.CommonProtos.dll" />
+            <InputAssemblies Include="Google.Apis.Auth.PlatformServices.dll" />
+            <InputAssemblies Include="Google.Apis.Auth.dll" />
+            <InputAssemblies Include="Google.Apis.Core.dll" />
+            <InputAssemblies Include="Google.Apis.dll" />
+            <InputAssemblies Include="Google.LongRunning.dll" />
+            <InputAssemblies Include="Google.Protobuf.dll" />
+            <InputAssemblies Include="Google.Protobuf.dll" />
+            <InputAssemblies Include="Grpc.Auth.dll" />
+            <InputAssemblies Include="Grpc.Core.dll" />
+            <InputAssemblies Include="Newtonsoft.Json.dll" />
+            <InputAssemblies Include="System.Interactive.Async.dll" />
         </ItemGroup>
 
         <!-- These DLLs are not internalised because they contains types that are user-facing. Internalising would mess up the namespace. -->
         <ItemGroup>
-            <InternalizeExcludeAssemblies Include="^Google.Api.Gax" />
-            <InternalizeExcludeAssemblies Include="^Google.Protobuf.WellKnownTypes" />
-            <InternalizeExcludeAssemblies Include="^Grpc.Core" />
-            <InternalizeExcludeAssemblies Include="^Google.LongRunning" />
+            <InternalizeExcludeAssemblies Include="Improbable.SpatialOS.Platform" />
+            <InternalizeExcludeAssemblies Include="Google.Api.Gax" />
+            <InternalizeExcludeAssemblies Include="Google.LongRunning" />
+            <InternalizeExcludeAssemblies Include="Google.Protobuf.WellKnownTypes" />
+            <InternalizeExcludeAssemblies Include="Grpc.Core" />
         </ItemGroup>
         
-        <ILRepack Parallel="true" OutputType="$(OutputType)" MainAssembly="$(AssemblyName).dll" OutputAssembly="$(AssemblyName).dll" InputAssemblies="@(InputAssemblies)"  InternalizeExcludeAssemblies="@(InternalizeExcludeAssemblies)" Internalize="true" WorkingDirectory="$(WorkingDirectory)" />
+        <ILRepack Parallel="true" OutputType="$(OutputType)" MainAssembly="$(AssemblyName).dll" OutputAssembly="$(AssemblyName).dll" InputAssemblies="@(InputAssemblies)" InternalizeExcludeAssemblies="@(InternalizeExcludeAssemblies)" Internalize="true" WorkingDirectory="$(WorkingDirectory)" />
 
         <ItemGroup>
             <AssembliesToDelete Include="$(WorkingDirectory)/%(InputAssemblies.Identity)" />

--- a/scripts/generateapis.sh
+++ b/scripts/generateapis.sh
@@ -7,7 +7,7 @@ cd "${REPO_ROOT}"
 
 source scripts/includes/bazel.sh
 
-generate_api() {
+function generate_api() {
     NAME="$1"
     VERSION="$2"
     PACKAGE="apis/${NAME}_${VERSION}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,8 +5,9 @@ set -e -u -o pipefail
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "${REPO_ROOT}"
 
-ARTEFACT_DIR="${REPO_ROOT}/artefacts"
-OUTPUT_DIR="${REPO_ROOT}/apis/bin/Release"
+PACKAGE_DIR="${REPO_ROOT}/artefacts"
+BIN_DIR="${REPO_ROOT}/apis/bin/Release"
+TARGET_FRAMEWORK="netstandard1.6"
 
 if [[ -z "${SDK_VERSION+x}" ]]; then
   echo "Please set the SDK_VERSION environment variable to the correct version."
@@ -20,26 +21,23 @@ if [[ -z "${NUGET_API_KEY+x}" ]]; then
 fi
 
 echo "--- Clearing artefacts from previous runs"
-rm -rf "${ARTEFACT_DIR}"
-mkdir -p "${ARTEFACT_DIR}"
+rm -rf "${PACKAGE_DIR}"
+mkdir -p "${PACKAGE_DIR}"
 
 echo "--- Preparing artefacts for release"
-msbuild "${REPO_ROOT}/apis/apis.csproj" /t:Restore
-msbuild "${REPO_ROOT}/apis/apis.csproj" \
-  /p:Configuration=Release \
-  /p:Version="${SDK_VERSION}" \
-  /t:Clean,Build \
-  -verbosity:minimal
+dotnet build apis/apis.csproj --configuration Release --framework "${TARGET_FRAMEWORK}"
+dotnet pack apis/apis.csproj --no-build --configuration Release -p:"PackageVersion=${SDK_VERSION}"
 
-pushd "${OUTPUT_DIR}/net451"
-zip -r "${ARTEFACT_DIR}/${SDK_VERSION}-net451.zip" ./*
+pushd "${BIN_DIR}/${TARGET_FRAMEWORK}"
+zip -r "${PACKAGE_DIR}/${SDK_VERSION}.zip" ./*
 popd
 
-cp "${OUTPUT_DIR}/Improbable.SpatialOS.Platform.${SDK_VERSION}.nupkg" "${ARTEFACT_DIR}"
+cp "${BIN_DIR}/Improbable.SpatialOS.Platform.${SDK_VERSION}.nupkg" "${PACKAGE_DIR}"
 
 echo "--- Publishing to NuGet"
-nuget setApiKey "${NUGET_API_KEY}"
-nuget push "${ARTEFACT_DIR}/Improbable.SpatialOS.Platform.${SDK_VERSION}.nupkg" -Source https://api.nuget.org/v3/index.json
+dotnet nuget push "${PACKAGE_DIR}/Improbable.SpatialOS.Platform.${SDK_VERSION}.nupkg" \
+  --source https://api.nuget.org/v3/index.json \
+  --api-key "${NUGET_API_KEY}"
 
 echo "--- Publishing to SpatialOS Package service"
-package_client publish platform_sdk csharp "${SDK_VERSION}" "${ARTEFACT_DIR}/${SDK_VERSION}-net451.zip"
+package_client publish platform_sdk csharp "${SDK_VERSION}" "${PACKAGE_DIR}/${SDK_VERSION}.zip"


### PR DESCRIPTION
This PR aims to eliminate a few of the issues that I have been encountering in the regeneration of the SDK and its associated scripts.

Highlights:
- Move from using a bastardised / mixed version of .NET Framework 4.5.1 with .NET Standard 1.5 to using .NET Standard 1.6. This could technically be considered as a breaking change although the current situation is not very clear on requirements: .NET Standard 1.5 is only compatible with .NET Framework 4.**6**.1 and thus our current scheme is undefined.

- Use of `dotnet` CLI instead of `msbuild` as it nicely wraps functionality of both `msbuild` and `nuget` and has cleaner CLI interfaces.

- Update of the used docker container to a more recent mainline image (and LTS).