### PR TITLE
Updating the queue so we can scale down the old one

### DIFF
--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -17,7 +17,7 @@ common: &common
     - "permission_set=builder"
     - "platform=linux"
     - "scaler_version=2"
-    - "queue=${CI_BUILDER_QUEUE:-v3-1558960120-4a170e85e982b36f-------z}"
+    - "queue=${CI_BUILDER_QUEUE:-v3-1564411674-9c5746811d9f2beb-------z}"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:
     automatic:

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -17,7 +17,7 @@ common: &common
     - "permission_set=builder"
     - "platform=linux"
     - "scaler_version=2"
-    - "queue=${CI_BUILDER_QUEUE:-v3-1558960120-4a170e85e982b36f-------z}"
+    - "queue=${CI_BUILDER_QUEUE:-v3-1564411674-9c5746811d9f2beb-------z}"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:
     automatic:


### PR DESCRIPTION
Updating to the latest platform builder queue so that we can scale down the old machines.