### PR TITLE
Revert ILRepack introduced by #24

### DIFF
--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -17,6 +17,7 @@ common: &common
     - "permission_set=builder"
     - "platform=linux"
     - "scaler_version=2"
+    - "machine_type=quarter"
     - "queue=${CI_BUILDER_QUEUE:-v3-1564411674-9c5746811d9f2beb-------z}"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -17,6 +17,7 @@ common: &common
     - "permission_set=builder"
     - "platform=linux"
     - "scaler_version=2"
+    - "machine_type=quarter"
     - "queue=${CI_BUILDER_QUEUE:-v3-1564411674-9c5746811d9f2beb-------z}"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:

--- a/apis/apis.csproj
+++ b/apis/apis.csproj
@@ -22,51 +22,7 @@
 
     <ItemGroup>
       <PackageReference Include="Google.LongRunning" Version="1.0.0" />
-      <PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" />
       <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0-preview.2" />
     </ItemGroup>
-
-    <!-- For details on configuring ILRepack see https://www.phillipsj.net/posts/using-ilrepack-with-dotnet-core-sdk-and-dotnet-standard -->
-    <Target Name="ILRepack" AfterTargets="Pack" Condition="'$(Configuration)' == 'Release' ">
-        <PropertyGroup>
-            <WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\netstandard1.6</WorkingDirectory>
-        </PropertyGroup>
-
-        <ItemGroup>
-			<InputAssemblies Include="Improbable.SpatialOS.Platform.dll" />
-            <InputAssemblies Include="Google.Api.CommonProtos.dll" />
-            <InputAssemblies Include="Google.Api.Gax.Grpc.dll" />
-            <InputAssemblies Include="Google.Api.Gax.dll" />
-            <InputAssemblies Include="Google.Apis.Auth.PlatformServices.dll" />
-            <InputAssemblies Include="Google.Apis.Auth.dll" />
-            <InputAssemblies Include="Google.Apis.Core.dll" />
-            <InputAssemblies Include="Google.Apis.dll" />
-            <InputAssemblies Include="Google.LongRunning.dll" />
-            <InputAssemblies Include="Google.Protobuf.dll" />
-            <InputAssemblies Include="Google.Protobuf.dll" />
-            <InputAssemblies Include="Grpc.Auth.dll" />
-            <InputAssemblies Include="Grpc.Core.dll" />
-            <InputAssemblies Include="Newtonsoft.Json.dll" />
-            <InputAssemblies Include="System.Interactive.Async.dll" />
-        </ItemGroup>
-
-        <!-- These DLLs are not internalised because they contains types that are user-facing. Internalising would mess up the namespace. -->
-        <ItemGroup>
-            <InternalizeExcludeAssemblies Include="Improbable.SpatialOS.Platform" />
-            <InternalizeExcludeAssemblies Include="Google.Api.Gax" />
-            <InternalizeExcludeAssemblies Include="Google.LongRunning" />
-            <InternalizeExcludeAssemblies Include="Google.Protobuf.WellKnownTypes" />
-            <InternalizeExcludeAssemblies Include="Grpc.Core" />
-        </ItemGroup>
-        
-        <ILRepack Parallel="true" OutputType="$(OutputType)" MainAssembly="$(AssemblyName).dll" OutputAssembly="$(AssemblyName).dll" InputAssemblies="@(InputAssemblies)" InternalizeExcludeAssemblies="@(InternalizeExcludeAssemblies)" Internalize="true" WorkingDirectory="$(WorkingDirectory)" />
-
-        <ItemGroup>
-            <AssembliesToDelete Include="$(WorkingDirectory)/%(InputAssemblies.Identity)" />
-        </ItemGroup>
-
-        <Delete Files="@(AssembliesToDelete)" />
-        
-    </Target>
 
 </Project>


### PR DESCRIPTION
The ILRepack has introduced type conflict issues that are not easily
solved. This boils down to the fact that the public API surface of the
Platform SDK exposes types provided by dependencies. ILRepack creates an
artificial assembly to export those types.

However any user will need to import the original dependency assembly in
order to construct function arguments with the types in question. This
will result in duplicate type errors as they will exist in both the
user-imported dependency and the new artificial assembly created by the
ILRepack.