### PR TITLE
COMP-2959: Example how to use CN Silo from C# Platform SDK

### DIFF
--- a/examples/CNSilo/CNSilo.csproj
+++ b/examples/CNSilo/CNSilo.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\apis\apis.csproj" />
+      <ProjectReference Include="..\Utils\Utils.csproj" />
+      <ProjectReference Include="..\WorkerSDKWrapper\WorkerSDKWrapper.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Reference Include="Improbable.WorkerSdkCsharp, Version=13.4.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>..\WorkerSDKWrapper\Improbable.WorkerSdkCsharp.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+
+</Project>

--- a/examples/CNSilo/Program.cs
+++ b/examples/CNSilo/Program.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Google.Protobuf.WellKnownTypes;
+using Improbable.SpatialOS.Deployment.V1Beta1;
+using Improbable.SpatialOS.Platform.Common;
+using Improbable.SpatialOS.PlayerAuth.V2Alpha1;
+using Improbable.Worker;
+using Improbable.Worker.Alpha;
+using Utils;
+using Deployment = Improbable.SpatialOS.Deployment.V1Beta1.Deployment;
+using Locator = Improbable.Worker.Alpha.Locator;
+using LocatorParameters = Improbable.Worker.Alpha.LocatorParameters;
+
+namespace CNSilo
+{
+    internal class CNSilo : ScenarioBase
+    {
+        /// <summary>
+        ///     Specifies the CN silo endpoint of SpatialOS, where the domain is *.spatialoschina.com rather then the default *.improbable.io.
+        /// </summary>
+        private static readonly PlatformApiEndpoint Endpoint =
+            new PlatformApiEndpoint("playerauth.api.spatialoschina.com", 443);
+
+        /// <summary>
+        ///     Specifies the CN silo authorization endpoint of SpatialOS, where the domain is *.spatialoschina.com rather then the default *.improbable.io.
+        /// </summary>
+        private const string AuthorizationServerUrl = "https://auth.spatialoschina.com/auth/v1/authcode";
+
+        /// <summary>
+        ///     Specifies the CN silo token server endpoint of SpatialOS, where the domain is *.spatialoschina.com rather then the default *.improbable.io.
+        /// </summary>
+        private const string TokenServerUrl = "https://auth.spatialoschina.com/auth/v1/token";
+
+        private static readonly PlatformRefreshTokenCredential CredentialWithProvidedToken =
+            new PlatformRefreshTokenCredential(RefreshToken, AuthorizationServerUrl, TokenServerUrl);
+
+        private readonly PlayerAuthServiceClient _playerAuthServiceClient =
+            PlayerAuthServiceClient.Create(credentials: CredentialWithProvidedToken, endpoint: Endpoint);
+
+        /// <summary>
+        ///     PLEASE REPLACE.
+        ///     Your SpatialOS project name. This project needs to exist in CN silo.
+        ///     It should be the same as the name specified in the local project definition file (spatialos.json) used to start the local API service.
+        /// </summary>
+        private const string ProjectName = "platform_sdk_examples";
+
+        /// <summary>
+        ///     PLEASE REPLACE.
+        ///     The SpatialOS refresh token of a service account or a user account.
+        ///     NOTE: Make sure that your token has been issued for CN silo for this example!
+        /// </summary>
+        private static string RefreshToken =>
+            Environment.GetEnvironmentVariable("IMPROBABLE_REFRESH_TOKEN") ?? "PLEASE_REPLACE_ME";
+
+        protected override void Setup()
+        {
+        }
+
+        protected override void Run()
+        {
+            Console.WriteLine("Creating a PlayerIdentityToken with CN Silo");
+            var playerIdentityTokenResponse = _playerAuthServiceClient.CreatePlayerIdentityToken(
+                new CreatePlayerIdentityTokenRequest
+                {
+                    Provider = "provider",
+                    PlayerIdentifier = "player_identifier",
+                    ProjectName = ProjectName
+                });
+
+            Console.WriteLine("Verifying PlayerIdentityToken with CN Silo");
+            var decodePlayerIdentityTokenResponse = _playerAuthServiceClient.DecodePlayerIdentityToken(
+                new DecodePlayerIdentityTokenRequest
+                {
+                    PlayerIdentityToken = playerIdentityTokenResponse.PlayerIdentityToken
+                });
+            var playerIdentityToken = decodePlayerIdentityTokenResponse.PlayerIdentityToken;
+            if (playerIdentityToken.Provider != "provider") throw new Exception("Provider not recognised.");
+            if (playerIdentityToken.ProjectName != ProjectName) throw new Exception("Project not recognised.");
+            if (DateTime.Now.CompareTo(playerIdentityToken.ExpiryTime.ToDateTime()) > 0)
+                throw new Exception("PlayerIdentityToken expired.");
+        }
+
+        protected override void Cleanup()
+        {
+        }
+    }
+
+    internal class Program
+    {
+        private static readonly ScenarioBase Scenario = new CNSilo();
+
+        private static void Main(string[] args)
+        {
+            Scenario.Execute();
+        }
+    }
+}

--- a/examples/examples.sln
+++ b/examples/examples.sln
@@ -16,6 +16,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkerSDKWrapper", "WorkerS
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CapacityLimit", "CapacityLimit\CapacityLimit.csproj", "{62B604B5-0203-4F6B-8BB7-208D5ED3E66C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CNSilo", "CNSilo\CNSilo.csproj", "{4BFD963B-DCBE-4112-9297-5F02BAE5D305}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,5 +56,9 @@ Global
 		{5850AA6F-0CFE-4AB8-B8F4-EB32C032A47A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5850AA6F-0CFE-4AB8-B8F4-EB32C032A47A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5850AA6F-0CFE-4AB8-B8F4-EB32C032A47A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BFD963B-DCBE-4112-9297-5F02BAE5D305}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BFD963B-DCBE-4112-9297-5F02BAE5D305}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BFD963B-DCBE-4112-9297-5F02BAE5D305}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BFD963B-DCBE-4112-9297-5F02BAE5D305}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/scripts/runtest-cn-silo.sh
+++ b/scripts/runtest-cn-silo.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+REPO_ROOT="$(dirname "$0")/.."
+cd "${REPO_ROOT}"
+
+SDK_VERSION_PREMERGE="888.8.8-PREMERGE"
+DOCKER_IMAGE="platform-sdk/csharp:${SDK_VERSION_PREMERGE}"
+
+if [[ -z "${IMPROBABLE_REFRESH_TOKEN+x}" ]]; then
+  echo "IMPROBABLE_REFRESH_TOKEN is unset. Please make sure you set this variable to a valid CN silo SpatialOS refresh token."
+  exit 1
+fi
+
+echo "--- Building docker image"
+docker build \
+  --build-arg "IMPROBABLE_REFRESH_TOKEN=${IMPROBABLE_REFRESH_TOKEN}" \
+  --build-arg "SDK_VERSION=${SDK_VERSION_PREMERGE}" \
+  --tag "${DOCKER_IMAGE}" \
+  "${REPO_ROOT}"
+
+echo "--- Running CN Silo Scenario"
+docker run \
+  --workdir="/workspace/examples/CNSilo" \
+  "${DOCKER_IMAGE}" \
+  /bin/bash -c "dotnet run --no-build --configuration Release"


### PR DESCRIPTION
To test this out:
```
spatial auth login --environment cn-production
export IMPROBABLE_REFRESH_TOKEN=$(cat ~/.improbable/oauth2/oauth2_refresh_token_cn-production)
scripts/runtest-cn-silo.sh
```
This requires Docker and has been tested on macOS only, but the key parts of how to connect to CN silo are clear from the code.