### PR TITLE
ENG-3288 RuntimeVersion is now always required when creating a deployment

### DIFF
--- a/apis/deployment_v1alpha1/Deployment.cs
+++ b/apis/deployment_v1alpha1/Deployment.cs
@@ -3830,6 +3830,7 @@ namespace Improbable.SpatialOS.Deployment.V1Alpha1 {
     /// `assembly_id`
     /// `starting_snapshot_id`
     /// `launch_config`
+    /// `runtime_version`
     ///
     /// In addition, these fields are optional:
     /// `region_code`

--- a/apis/deployment_v1beta1/Deployment.cs
+++ b/apis/deployment_v1beta1/Deployment.cs
@@ -599,7 +599,7 @@ namespace Improbable.SpatialOS.Deployment.V1Beta1 {
     public const int RuntimeVersionFieldNumber = 18;
     private string runtimeVersion_ = "";
     /// <summary>
-    /// Only use this field if you were directed to do so by SpatialOS support
+    /// This field is required.
     ///
     /// The version of the Runtime to start the deployment.
     /// </summary>
@@ -3573,7 +3573,7 @@ namespace Improbable.SpatialOS.Deployment.V1Beta1 {
     public const int RuntimeVersionFieldNumber = 9;
     private string runtimeVersion_ = "";
     /// <summary>
-    /// Only use this field if you were directed to do so by SpatialOS support
+    /// This field is required.
     ///
     /// The version of the Runtime to start the deployment.
     /// </summary>

--- a/examples/BYOAuthFlow/Program.cs
+++ b/examples/BYOAuthFlow/Program.cs
@@ -43,6 +43,12 @@ namespace BYOAuthFlow
         ///     The assembly you want the cloud deployment to use.
         /// </summary>
         private const string AssemblyId = "blank_project";
+        
+        /// <summary>
+        ///     PLEASE REPLACE.
+        ///     The runtime version you want the cloud deployment to use.
+        /// </summary>
+        private const string RuntimeVersion = "14.5.4";
 
         private const string LocatorServerAddress = "locator.improbable.io";
         private const int LocatorServerPort = 443;
@@ -86,7 +92,8 @@ namespace BYOAuthFlow
                     ConfigJson = launchConfig
                 },
                 AssemblyName = AssemblyId,
-                Tags = {ScenarioDeploymentTag}
+                Tags = {ScenarioDeploymentTag},
+                RuntimeVersion = RuntimeVersion
             }).PollUntilCompleted().GetResultOrNull();
         }
 

--- a/examples/CapacityLimit/Program.cs
+++ b/examples/CapacityLimit/Program.cs
@@ -29,7 +29,13 @@ namespace CapacityLimit
         ///     The assembly you want the cloud deployment to use.
         /// </summary>
         private const string AssemblyId = "blank_project";
-
+        
+        /// <summary>
+        ///     PLEASE REPLACE.
+        ///     The runtime version you want the cloud deployment to use.
+        /// </summary>
+        private const string RuntimeVersion = "14.5.4";
+        
         /// <summary>
         ///     PLEASE REPLACE.
         ///     The path to a valid launch configuration JSON file.
@@ -79,7 +85,8 @@ namespace CapacityLimit
                     {
                         ConfigJson = File.ReadAllText(LaunchConfigFilePath)
                     },
-                    AssemblyName = AssemblyId
+                    AssemblyName = AssemblyId,
+                    RuntimeVersion = RuntimeVersion
                 })
                 .PollUntilCompleted();
         }

--- a/examples/GameMaintenance/Program.cs
+++ b/examples/GameMaintenance/Program.cs
@@ -29,7 +29,13 @@ namespace GameMaintenance
         ///     The assembly you want the cloud deployment to use.
         /// </summary>
         private const string AssemblyId = "blank_project";
-
+                
+        /// <summary>
+        ///     PLEASE REPLACE.
+        ///     The runtime version you want the cloud deployment to use.
+        /// </summary>
+        private const string RuntimeVersion = "14.5.4";
+        
         /// <summary>
         ///     PLEASE REPLACE.
         ///     The path to a valid snapshot for the target assembly.
@@ -114,6 +120,7 @@ namespace GameMaintenance
                     StartingSnapshotId = latestSnapshot.Id,
                     LaunchConfig = currentLiveDeployment.Deployment.LaunchConfig,
                     AssemblyName = currentLiveDeployment.Deployment.AssemblyName,
+                    RuntimeVersion = currentLiveDeployment.Deployment.RuntimeVersion,
                 })
                 .PollUntilCompleted()
                 .GetResultOrNull();
@@ -181,7 +188,8 @@ namespace GameMaintenance
                         ConfigJson = File.ReadAllText(LaunchConfigFilePath)
                     },
                     Tags = {"my_live_tag"},
-                    AssemblyName = AssemblyId
+                    AssemblyName = AssemblyId,
+                    RuntimeVersion = RuntimeVersion
                 })
                 .PollUntilCompleted();
         }

--- a/examples/ReplicateState/Program.cs
+++ b/examples/ReplicateState/Program.cs
@@ -34,7 +34,13 @@ namespace ReplicateState
         ///     The assembly you want the cloud deployment to use.
         /// </summary>
         private const string AssemblyId = "blank_project";
-
+                
+        /// <summary>
+        ///     PLEASE REPLACE.
+        ///     The runtime version you want the cloud deployment to use.
+        /// </summary>
+        private const string RuntimeVersion = "14.5.4";
+        
         /// <summary>
         ///     PLEASE REPLACE.
         ///     The port that the local API service is running on.
@@ -148,6 +154,7 @@ namespace ReplicateState
                     ConfigJson = File.ReadAllText(LaunchConfigFilePath)
                 },
                 AssemblyId = AssemblyId,
+                RuntimeVersion = RuntimeVersion,
                 StartingSnapshotId = newSnapshot.Id
             };
             _cloudDeployment = CloudDeploymentServiceClient.CreateDeployment(new CreateDeploymentRequest
@@ -179,7 +186,8 @@ namespace ReplicateState
                     LaunchConfig = new LaunchConfig
                     {
                         ConfigJson = launchConfig
-                    }
+                    },
+                    RuntimeVersion = RuntimeVersion
                 }
             }).PollUntilCompleted().GetResultOrNull();
             


### PR DESCRIPTION
- Updated all examples to provide a RuntimeVersion when creating a deployment
- Manually updated the API references to mention that the field is now required. I'm aware that these changes will be overwritten the first time we regenerate the SDK from the protos, but since doing that is currently blocked on releasing a new major of the Platform SDK and we have no deadline for it, I think this will do for the time being. This ticket tracks doing these changes in the proper auto-generated way: https://improbableio.atlassian.net/browse/ENG-3290

I've also submitted suggested edits to the official README.io docs matching the changes made to the API reference and I'm in the process of submitting them for the updated to the code examples.