### PR TITLE
Platform Queue moving to virtal BK Queue's for updates - Gen 2.

### DIFF
--- a/.buildkite/nightly.steps.yaml
+++ b/.buildkite/nightly.steps.yaml
@@ -18,7 +18,7 @@ common: &common
     - "platform=linux"
     - "scaler_version=2"
     - "machine_type=quarter"
-    - "queue=${CI_BUILDER_QUEUE:-v3-1564411674-9c5746811d9f2beb-------z}"
+    - "queue=${CI_BUILDER_QUEUE:-virtual-latest}"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:
     automatic:

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -18,7 +18,7 @@ common: &common
     - "platform=linux"
     - "scaler_version=2"
     - "machine_type=quarter"
-    - "queue=${CI_BUILDER_QUEUE:-v3-1564411674-9c5746811d9f2beb-------z}"
+    - "queue=${CI_BUILDER_QUEUE:-virtual-latest}"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:
     automatic:


### PR DESCRIPTION
Update Buildkite queue to use virtual queues, as such you will have automatic upgrades to use the latest version of this queue.

This queue was picked by running the following.

```
circle ci queues list --labels "platform=linux,capable_of_building=platform"
v4-22-02-07-122806-bk24124-9032f685-at-1645210414
v4-22-02-07-122806-bk24124-9032f685-at-1645210314
```

[_Created by Sourcegraph batch change `gavinelder/update-v3-pipelines`._](https://code.i8e.io/users/gavinelder/batch-changes/update-v3-pipelines)